### PR TITLE
Change title and lede on guide pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "localgovdrupal/localgov_core": "dev-master"
+    "localgovdrupal/localgov_core": "dev-feature/localgov-87-title-block"
   },
   "require-dev": {
     "localgovdrupal/localgov_services": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "localgovdrupal/localgov_core": "dev-feature/dev-master"
+    "localgovdrupal/localgov_core": "dev-master"
   },
   "require-dev": {
     "localgovdrupal/localgov_services": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "localgovdrupal/localgov_core": "dev-feature/localgov-87-title-block"
+    "localgovdrupal/localgov_core": "dev-feature/dev-master"
   },
   "require-dev": {
     "localgovdrupal/localgov_services": "dev-master",

--- a/localgov_guides.services.yml
+++ b/localgov_guides.services.yml
@@ -1,0 +1,6 @@
+services:
+  # Alter page header.
+  localgov_guides.page_header:
+    class: Drupal\localgov_guides\EventSubscriber\PageHeaderSubscriber
+    tags:
+      - { name: 'event_subscriber' }

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\localgov_guides\EventSubscriber;
+
+use Drupal\node\Entity\Node;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
+
+/**
+ * Class PageHeaderSubscriber.
+ *
+ * @package Drupal\localgov_guides\EventSubscriber
+ */
+class PageHeaderSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PageHeaderDisplayEvent::EVENT_NAME => ['setPageHeader', 0],
+    ];
+  }
+
+  /**
+   * Set page title and lede.
+   */
+  public function setPageHeader(PageHeaderDisplayEvent $event) {
+    if ($event->getEntity() instanceof Node &&
+      $event->getEntity()->bundle() == 'localgov_guides_page' &&
+      $event->getEntity()->localgov_guides_parent
+    ) {
+      $overview = $event->getEntity()->localgov_guides_parent->entity;
+      $event->setTitle($overview->getTitle());
+      if ($overview->get('body')->summary) {
+        $event->setLede([
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $overview->get('body')->summary,
+        ]);
+      }
+      else {
+        $event->setLede('');
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Subscribes to the PageHeaderDisplayEvent event provided in the feature/localgov-87-title-block branch in localgov_core to modify the title and lede in the PageHeaderBlock block.

Related merge requests:

- Block and event logic: https://github.com/localgovdrupal/localgov_core/pull/25
- Hide page header block for campaign content types: https://github.com/localgovdrupal/localgov_campaigns/pull/27

Discussion of why this block exists and does what is does is here: https://github.com/localgovdrupal/localgov/issues/87