### PR TITLE
Fix/22 next previous

### DIFF
--- a/localgov_guides.module
+++ b/localgov_guides.module
@@ -22,7 +22,9 @@ function localgov_guides_theme($existing, $type, $theme, $path) {
     'guides_prev_next_block' => [
       'variables' => [
         'previous_url' => NULL,
+        'previous_title' => NULL,
         'next_url' => NULL,
+        'next_title' => NULL,
       ],
     ],
     'node__localgov_guides_overview__full' => [

--- a/src/Plugin/Block/GuidesPrevNextBlock.php
+++ b/src/Plugin/Block/GuidesPrevNextBlock.php
@@ -18,22 +18,28 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
   public function build() {
     $this->setPages();
     $previous_url = '';
+    $previous_title = '';
     $next_url = '';
+    $next_title = '';
 
     if ($this->node->bundle() == 'localgov_guides_overview' and count($this->guidePages) > 0) {
       $next_url = $this->guidePages[0]->toUrl();
+      $next_title = $this->guidePages[0]->localgov_guides_section_title->value;
     }
 
     if ($this->node->bundle() == 'localgov_guides_page') {
       $page_delta = array_search(['target_id' => $this->node->id()], $this->overview->localgov_guides_pages->getValue());
       if (!empty($this->guidePages[$page_delta - 1])) {
         $previous_url = $this->guidePages[$page_delta - 1]->toUrl();
+        $previous_title = $this->guidePages[$page_delta - 1]->localgov_guides_section_title->value;
       }
       else {
         $previous_url = $this->overview->toUrl();
+        $previous_title = $this->overview->localgov_guides_section_title->value;
       }
       if (!empty($this->guidePages[$page_delta + 1])) {
         $next_url = $this->guidePages[$page_delta + 1]->toUrl();
+        $next_title = $this->guidePages[$page_delta + 1]->localgov_guides_section_title->value;
       }
     }
 
@@ -41,7 +47,9 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
     $build[] = [
       '#theme' => 'guides_prev_next_block',
       '#previous_url' => $previous_url,
+      '#previous_title' => $previous_title,
       '#next_url' => $next_url,
+      '#next_title' => $next_title,
     ];
 
     return $build;

--- a/templates/guides-contents-block.html.twig
+++ b/templates/guides-contents-block.html.twig
@@ -24,7 +24,7 @@
         {% endif %}
       {% else %}
         {% if link.url.options.attributes.class == 'active' %}
-          <li><span class="progress--step progress--active"></span> {{ link.text }} </li>
+          <li><span aria-current="page" class="progress--step progress--active"></span> {{ link.text }} </li>
         {% else %}
           <li><span class="progress--step"></span> {{ link }} </li>
         {% endif %}

--- a/templates/guides-prev-next-block.html.twig
+++ b/templates/guides-prev-next-block.html.twig
@@ -4,7 +4,7 @@
 * Default theme implementation for the guides_prev_next_block block.
 */
 #}
-<nav class="navigation-link-container">
-  {% if previous_url %}<button type="button" onclick="location.href='{{ previous_url }}'" class="btn btn-carbon"><span class="fa fa-chevron-left"></span>Previous</button>{% endif %}
-  {% if next_url %}<button type="button" onclick="location.href='{{ next_url }}'" class="btn btn-primary"><span class="fa fa-chevron-right"></span>Next</button>{% endif %}
+<nav class="localgov_guides--navigation">
+  {% if previous_url %}<a href="{{ previous_url }}" class="btn btn-carbon localgov_guides--previous" aria-label="Previous: {{ previous_title }}"><span class="fa fa-chevron-left"></span>Previous</a>{% endif %}
+  {% if next_url %}<a href="{{ next_url }}" class="btn btn-primary localgov_guides--next" aria-label="Next: {{ next_title }}"><span class="fa fa-chevron-right"></span>Next</a>{% endif %}
 </nav>

--- a/templates/node--localgov-guides-overview--full.html.twig
+++ b/templates/node--localgov-guides-overview--full.html.twig
@@ -6,6 +6,7 @@
 #}
 {%
   set classes = [
+    'localgov_guides',
     'node',
     'node--type-' ~ node.bundle|clean_class,
     node.isPromoted() ? 'node--promoted',

--- a/templates/node--localgov-guides-page--full.html.twig
+++ b/templates/node--localgov-guides-page--full.html.twig
@@ -6,6 +6,7 @@
 #}
 {%
   set classes = [
+    'localgov_guides',
     'node',
     'node--type-' ~ node.bundle|clean_class,
     node.isPromoted() ? 'node--promoted',


### PR DESCRIPTION
Closes #22. This PR:

- Changes guide next / previous buttons to links
- Add aria-label attributes to the links to provide context for users of AT
- Adds aria-current attribute to the current page in the overview
- Adds a wrapper class to page templates

Styling is handled in theme, see: [/localgovdrupal/localgov_theme/pull/44](/localgovdrupal/localgov_theme/pull/44)