### PR TITLE
Fix/navigation unpublish move

### DIFF
--- a/localgov_guides.module
+++ b/localgov_guides.module
@@ -57,15 +57,23 @@ function localgov_guides_node_update(NodeInterface $node) {
       ($previous = $node->original) &&
       ($previous->localgov_guides_parent->target_id != $node->localgov_guides_parent->target_id)
     ) {
+      // There is a previous version of this page.
+      // The guide overview it is in isn't the same in the previous and new
+      // versions.
       if ($old_parent = $node->original->localgov_guides_parent->entity) {
+        // Getting the old guide overview we look for all the references to this
+        // page.
         foreach (array_keys($old_parent->localgov_guides_pages->getValue(), ['target_id' => $node->id()]) as $offset) {
+          // And remove each reference on the old parent to this page.
           $old_parent->localgov_guides_pages->offsetUnset($offset);
         }
         $old_parent->save();
       }
     }
     if ($parent = $node->localgov_guides_parent->entity) {
+      // The current version of this page points to an overview.
       if (array_search(['target_id' => $node->id()], $parent->localgov_guides_pages->getValue()) === FALSE) {
+        // The overview does not yet point to this page, so we add it.
         $parent->localgov_guides_pages->appendItem(['target_id' => $node->id()]);
         $parent->save();
       }

--- a/localgov_guides.module
+++ b/localgov_guides.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
+use Drupal\localgov_guides\ChildParentRelationship;
 
 /**
  * Implements hook_theme().
@@ -43,7 +44,11 @@ function localgov_guides_theme($existing, $type, $theme, $path) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function localgov_guides_node_insert(NodeInterface $node) {
-  localgov_guides_node_update($node);
+  if ($node->bundle() == 'localgov_guides_page') {
+    return \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ChildParentRelationship::class)
+      ->pageUpdateOverview($node);
+  }
 }
 
 /**
@@ -53,31 +58,9 @@ function localgov_guides_node_insert(NodeInterface $node) {
  */
 function localgov_guides_node_update(NodeInterface $node) {
   if ($node->bundle() == 'localgov_guides_page') {
-    if (
-      ($previous = $node->original) &&
-      ($previous->localgov_guides_parent->target_id != $node->localgov_guides_parent->target_id)
-    ) {
-      // There is a previous version of this page.
-      // The guide overview it is in isn't the same in the previous and new
-      // versions.
-      if ($old_parent = $node->original->localgov_guides_parent->entity) {
-        // Getting the old guide overview we look for all the references to this
-        // page.
-        foreach (array_keys($old_parent->localgov_guides_pages->getValue(), ['target_id' => $node->id()]) as $offset) {
-          // And remove each reference on the old parent to this page.
-          $old_parent->localgov_guides_pages->offsetUnset($offset);
-        }
-        $old_parent->save();
-      }
-    }
-    if ($parent = $node->localgov_guides_parent->entity) {
-      // The current version of this page points to an overview.
-      if (array_search(['target_id' => $node->id()], $parent->localgov_guides_pages->getValue()) === FALSE) {
-        // The overview does not yet point to this page, so we add it.
-        $parent->localgov_guides_pages->appendItem(['target_id' => $node->id()]);
-        $parent->save();
-      }
-    }
+    return \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ChildParentRelationship::class)
+      ->pageUpdateOverview($node);
   }
 }
 
@@ -88,7 +71,9 @@ function localgov_guides_node_update(NodeInterface $node) {
  */
 function localgov_guides_node_prepare_form(NodeInterface $node, $operation, FormStateInterface $form) {
   if ($node->bundle() == 'localgov_guides_overview') {
-    localgov_guides_overview_pages_check($node);
+    return \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ChildParentRelationship::class)
+      ->overviewPagesCheck($node);
   }
 }
 
@@ -100,28 +85,9 @@ function localgov_guides_node_prepare_form(NodeInterface $node, $operation, Form
  */
 function localgov_guides_node_presave(NodeInterface $node) {
   if ($node->bundle() == 'localgov_guides_overview') {
-    localgov_guides_overview_pages_check($node);
-  }
-}
-
-/**
- * Check backward references.
- */
-function localgov_guides_overview_pages_check(NodeInterface $node) {
-  $query = \Drupal::entityQuery('node');
-  $query->condition('type', 'localgov_guides_page');
-  $query->condition('localgov_guides_parent', $node->id());
-  $actual_children = $query->execute();
-  $linked_children = array_column($node->localgov_guides_pages->getValue(), 'target_id');
-  $missing_children = array_diff($actual_children, $linked_children);
-  $extra_children = array_diff($linked_children, $actual_children);
-  foreach ($missing_children as $missing) {
-    $node->localgov_guides_pages->appendItem(['target_id' => $missing]);
-  }
-  foreach ($extra_children as $extra) {
-    foreach (array_keys($node->localgov_guides_pages->getValue(), ['target_id' => $extra]) as $offset) {
-      $node->localgov_guides_pages->offsetUnset($offset);
-    }
+    return \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ChildParentRelationship::class)
+      ->overviewPagesCheck($node);
   }
 }
 

--- a/localgov_guides.module
+++ b/localgov_guides.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -68,6 +69,50 @@ function localgov_guides_node_update(NodeInterface $node) {
         $parent->localgov_guides_pages->appendItem(['target_id' => $node->id()]);
         $parent->save();
       }
+    }
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_prepare_form().
+ *
+ * Check back-reference fields before editing overview.
+ */
+function localgov_guides_node_prepare_form(NodeInterface $node, $operation, FormStateInterface $form) {
+  if ($node->bundle() == 'localgov_guides_overview') {
+    localgov_guides_overview_pages_check($node);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * Check back-reference fields before saving.
+ * Especially if someone has changed a page since form load!
+ */
+function localgov_guides_node_presave(NodeInterface $node) {
+  if ($node->bundle() == 'localgov_guides_overview') {
+    localgov_guides_overview_pages_check($node);
+  }
+}
+
+/**
+ * Check backward references.
+ */
+function localgov_guides_overview_pages_check(NodeInterface $node) {
+  $query = \Drupal::entityQuery('node');
+  $query->condition('type', 'localgov_guides_page');
+  $query->condition('localgov_guides_parent', $node->id());
+  $actual_children = $query->execute();
+  $linked_children = array_column($node->localgov_guides_pages->getValue(), 'target_id');
+  $missing_children = array_diff($actual_children, $linked_children);
+  $extra_children = array_diff($linked_children, $actual_children);
+  foreach ($missing_children as $missing) {
+    $node->localgov_guides_pages->appendItem(['target_id' => $missing]);
+  }
+  foreach ($extra_children as $extra) {
+    foreach (array_keys($node->localgov_guides_pages->getValue(), ['target_id' => $extra]) as $offset) {
+      $node->localgov_guides_pages->offsetUnset($offset);
     }
   }
 }

--- a/localgov_guides.module
+++ b/localgov_guides.module
@@ -52,6 +52,17 @@ function localgov_guides_node_insert(NodeInterface $node) {
  */
 function localgov_guides_node_update(NodeInterface $node) {
   if ($node->bundle() == 'localgov_guides_page') {
+    if (
+      ($previous = $node->original) &&
+      ($previous->localgov_guides_parent->target_id != $node->localgov_guides_parent->target_id)
+    ) {
+      if ($old_parent = $node->original->localgov_guides_parent->entity) {
+        foreach (array_keys($old_parent->localgov_guides_pages->getValue(), ['target_id' => $node->id()]) as $offset) {
+          $old_parent->localgov_guides_pages->offsetUnset($offset);
+        }
+        $old_parent->save();
+      }
+    }
     if ($parent = $node->localgov_guides_parent->entity) {
       if (array_search(['target_id' => $node->id()], $parent->localgov_guides_pages->getValue()) === FALSE) {
         $parent->localgov_guides_pages->appendItem(['target_id' => $node->id()]);

--- a/src/ChildParentRelationship.php
+++ b/src/ChildParentRelationship.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\localgov_guides;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides helper to maintain overview page backreferences for guides.
+ */
+class ChildParentRelationship implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * ChildeParentRelationship constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Check backward references.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Overview node to have child references checked.
+   */
+  public function overviewPagesCheck(NodeInterface $node) {
+    $query = $this->entityTypeManager->getStorage('node')->getQuery();
+    $query->condition('type', 'localgov_guides_page');
+    $query->condition('localgov_guides_parent', $node->id());
+    $actual_children = $query->execute();
+    $linked_children = array_column($node->localgov_guides_pages->getValue(), 'target_id');
+    $missing_children = array_diff($actual_children, $linked_children);
+    $extra_children = array_diff($linked_children, $actual_children);
+    foreach ($missing_children as $missing) {
+      $node->localgov_guides_pages->appendItem(['target_id' => $missing]);
+    }
+    foreach ($extra_children as $extra) {
+      foreach (array_keys($node->localgov_guides_pages->getValue(), ['target_id' => $extra]) as $offset) {
+        $node->localgov_guides_pages->offsetUnset($offset);
+      }
+    }
+  }
+
+  /**
+   * Update overview references for a page.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The guide page node.
+   */
+  public function pageUpdateOverview(NodeInterface $node) {
+    if (
+      ($previous = $node->original) &&
+      ($previous->localgov_guides_parent->target_id != $node->localgov_guides_parent->target_id)
+    ) {
+      // There is a previous version of this page.
+      // The guide overview it is in isn't the same in the previous and new
+      // versions.
+      if ($old_parent = $node->original->localgov_guides_parent->entity) {
+        // Getting the old guide overview we look for all the references to this
+        // page.
+        foreach (array_keys($old_parent->localgov_guides_pages->getValue(), ['target_id' => $node->id()]) as $offset) {
+          // And remove each reference on the old parent to this page.
+          $old_parent->localgov_guides_pages->offsetUnset($offset);
+        }
+        $old_parent->save();
+      }
+    }
+    if ($parent = $node->localgov_guides_parent->entity) {
+      // The current version of this page points to an overview.
+      if (array_search(['target_id' => $node->id()], $parent->localgov_guides_pages->getValue()) === FALSE) {
+        // The overview does not yet point to this page, so we add it.
+        $parent->localgov_guides_pages->appendItem(['target_id' => $node->id()]);
+        $parent->save();
+      }
+    }
+  }
+
+}

--- a/src/Plugin/Block/GuidesContentsBlock.php
+++ b/src/Plugin/Block/GuidesContentsBlock.php
@@ -27,8 +27,10 @@ class GuidesContentsBlock extends GuidesAbstractBaseBlock {
     $links[] = $this->overview->toLink($this->overview->localgov_guides_section_title->value, 'canonical', $options);
     foreach ($this->guidePages as $guide_node) {
       assert($guide_node instanceof NodeInterface);
-      $options = $this->node->id() == $guide_node->id() ? ['attributes' => ['class' => 'active']] : [];
-      $links[] = $guide_node->toLink($guide_node->localgov_guides_section_title->value, 'canonical', $options);
+      if ($guide_node->access('view')) {
+        $options = $this->node->id() == $guide_node->id() ? ['attributes' => ['class' => 'active']] : [];
+        $links[] = $guide_node->toLink($guide_node->localgov_guides_section_title->value, 'canonical', $options);
+      }
     }
 
     $build = [];

--- a/tests/src/Functional/ContentsBlockTest.php
+++ b/tests/src/Functional/ContentsBlockTest.php
@@ -142,7 +142,61 @@ class ContentsBlockTest extends BrowserTestBase {
       'localgov_guides_parent' => ['target_id' => $overview->id()],
     ]);
     $this->drupalGet($overview->toUrl()->toString());
+    $xpath = '//ul[@class="progress"]/li';
+    $results = $this->xpath($xpath);
+    $this->assertEquals(5, count($results));
     $this->assertText('Guide page 4');
+    // Change title.
+    $pages[2]->title = 'New title page 2';
+    $pages[2]->save();
+    $this->drupalGet($overview->toUrl()->toString());
+    $this->assertNoText('Guide page 2');
+    $this->assertText('New title page 2');
+
+    // Another overview.
+    $overview_2 = $this->createNode([
+      'title' => 'Guide overview 2',
+      'type' => 'localgov_guides_overview',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    // Move a current revision to it.
+    $pages[0]->localgov_guides_parent = ['target_id' => $overview_2->id()];
+    $pages[0]->setNewRevision();
+    $pages[0]->save();
+    // Check overview.
+    $this->drupalGet($overview->toUrl()->toString());
+    $xpath = '//ul[@class="progress"]/li';
+    $results = $this->xpath($xpath);
+    $this->assertEquals(4, count($results));
+    $this->assertNotContains('Guide page 0', $results[1]->getText());
+    // Check new overview.
+    $this->drupalGet($overview_2->toUrl()->toString());
+    $xpath = '//ul[@class="progress"]/li';
+    $results = $this->xpath($xpath);
+    $this->assertEquals(2, count($results));
+    $this->assertContains('Guide overview', $results[0]->getText());
+    $this->assertNotContains($overview_2->toUrl()->toString(), $results[0]->getHtml());
+    $this->assertContains('Guide page 0', $results[1]->getText());
+    $this->assertContains($pages[0]->toUrl()->toString(), $results[1]->getHtml());
+
+    // Unpublish a page.
+    $pages[1]->status = NodeInterface::NOT_PUBLISHED;
+    $pages[1]->save();
+    // Still linked.
+    $content_admin = $this->drupalCreateUser(['bypass node access']);
+    $this->drupalLogin($content_admin);
+    $this->drupalGet($overview->toUrl()->toString());
+    $xpath = '//ul[@class="progress"]/li';
+    $results = $this->xpath($xpath);
+    $this->assertEquals(4, count($results));
+    $this->assertText('Guide page 1');
+    $this->drupalLogout();
+    // But not for anon.
+    $this->drupalGet($overview->toUrl()->toString());
+    $xpath = '//ul[@class="progress"]/li';
+    $results = $this->xpath($xpath);
+    $this->assertEquals(3, count($results));
+    $this->assertNoText('Guide page 1');
   }
 
 }

--- a/tests/src/Functional/ContentsBlockTest.php
+++ b/tests/src/Functional/ContentsBlockTest.php
@@ -135,8 +135,8 @@ class ContentsBlockTest extends BrowserTestBase {
     $this->assertContains($pages[2]->toUrl()->toString(), $results[3]->getHtml());
 
     // Check caching.
-    $this->createNode([
-      'title' => 'Guide page 4',
+    $pages[] = $this->createNode([
+      'title' => 'Guide page 3',
       'type' => 'localgov_guides_page',
       'status' => NodeInterface::PUBLISHED,
       'localgov_guides_parent' => ['target_id' => $overview->id()],
@@ -145,7 +145,7 @@ class ContentsBlockTest extends BrowserTestBase {
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
     $this->assertEquals(5, count($results));
-    $this->assertText('Guide page 4');
+    $this->assertText('Guide page 3');
     // Change title.
     $pages[2]->title = 'New title page 2';
     $pages[2]->save();
@@ -197,6 +197,14 @@ class ContentsBlockTest extends BrowserTestBase {
     $results = $this->xpath($xpath);
     $this->assertEquals(3, count($results));
     $this->assertNoText('Guide page 1');
+
+    // Delete page.
+    $pages[3]->delete();
+    $this->drupalGet($overview->toUrl()->toString());
+    $xpath = '//ul[@class="progress"]/li';
+    $results = $this->xpath($xpath);
+    $this->assertEquals(2, count($results));
+    $this->assertNoText('Guide page 3');
   }
 
 }

--- a/tests/src/Kernel/OverviewPageIntegrity.php
+++ b/tests/src/Kernel/OverviewPageIntegrity.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\Tests\localgov_guides\Kernel;
+
+use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Check maintaining integrity of backreference to children from overview.
+ *
+ * @group localgov_guides
+ */
+class OverviewPageIntegrity extends KernelTestBase {
+
+  use ContentTypeCreationTrait;
+  use EntityReferenceTestTrait;
+  use NodeCreationTrait;
+  use PathautoTestHelperTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'field',
+    'text',
+    'link',
+    'user',
+    'node',
+    'options',
+    'filter',
+    'localgov_core',
+    'localgov_guides',
+  ];
+
+  /**
+   * Service Landing page.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $serviceLanding;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setup();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig([
+      'filter',
+      'system',
+      'node',
+      'localgov_guides',
+    ]);
+
+  }
+
+  /**
+   * Test programmatic parent addition.
+   */
+  public function testServiceParentAddition() {
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+
+    $overviews = [];
+    $overviews[0] = $this->createNode([
+      'title' => 'Overview 1',
+      'type' => 'localgov_guides_overview',
+    ]);
+    $overviews[1] = $this->createNode([
+      'title' => 'Overview 2',
+      'type' => 'localgov_guides_overview',
+    ]);
+    $pages = [];
+    $pages[0] = $this->createNode([
+      'title' => 'Page 1',
+      'type' => 'localgov_guides_page',
+      'localgov_guides_parent' => ['target_id' => $overviews[0]->id()],
+    ]);
+    $pages[1] = $this->createNode([
+      'title' => 'Page 2',
+      'type' => 'localgov_guides_page',
+      'localgov_guides_parent' => ['target_id' => $overviews[0]->id()],
+    ]);
+
+    // Check the two created.
+    $storage->resetCache([$overviews[0]->id()]);
+    $overviews[0] = $storage->load($overviews[0]->id());
+    $child_pages = $overviews[0]->get('localgov_guides_pages')->getValue();
+    $this->assert(array_search(['target_id' => $pages[0]->id()], $child_pages) !== FALSE);
+    $this->assert(array_search(['target_id' => $pages[1]->id()], $child_pages) !== FALSE);
+
+    // While the overview is 'open' remove one node and add another.
+    $pages[1]->set('localgov_guides_parent', ['target_id' => $overviews[1]->id()]);
+    $pages[1]->save();
+    $pages[2] = $this->createNode([
+      'title' => 'Page 3',
+      'type' => 'localgov_guides_page',
+      'localgov_guides_parent' => ['target_id' => $overviews[0]->id()],
+    ]);
+
+    // Make sure it is saved with the original two pages.
+    $overviews[0]->set('localgov_guides_pages', $child_pages);
+    $overviews[0]->save();
+
+    // Check that the two pages are those actually referencing now.
+    $storage->resetCache([$overviews[0]->id()]);
+    $overviews[0] = $storage->load($overviews[0]->id());
+    $child_pages = $overviews[0]->get('localgov_guides_pages')->getValue();
+    $this->assert(array_search(['target_id' => $pages[0]->id()], $child_pages) !== FALSE);
+    $this->assert(array_search(['target_id' => $pages[1]->id()], $child_pages) === FALSE);
+    $this->assert(array_search(['target_id' => $pages[2]->id()], $child_pages) !== FALSE);
+  }
+
+}


### PR DESCRIPTION
Set of confusion that came up when working. This adds tests and corrects code for: 

 * Moving guide pages between guides; 
 * Unpublishing guide pages;
 * and does a check that delete is fine.

Unpublished, and revisions, are going to come up again, this checks they _work_, but with users wanting to link to unpublished (review workflow) content this is going to continue getting confused just using entity reference, and maintaining back-references isn't going to help. But for the basic case of content being published or unpublished, and some users being able to view it, this should be good.