### PR TITLE
Fix fatal error if overview not loaded

### DIFF
--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -28,9 +28,9 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
   public function setPageHeader(PageHeaderDisplayEvent $event) {
     if ($event->getEntity() instanceof Node &&
       $event->getEntity()->bundle() == 'localgov_guides_page' &&
-      $event->getEntity()->localgov_guides_parent
+      $event->getEntity()->localgov_guides_parent->entity
     ) {
-      $overview = $event->getEntity()->localgov_guides_parent->getEntity();
+      $overview = $event->getEntity()->localgov_guides_parent->entity;
       if (!empty($overview)) {
         $event->setTitle($overview->getTitle());
         if ($overview->get('body')->summary) {

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -31,7 +31,7 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       $event->getEntity()->localgov_guides_parent
     ) {
       $overview = $event->getEntity()->localgov_guides_parent->getEntity();
-      if (!empty($overview) {
+      if (!empty($overview)) {
         $event->setTitle($overview->getTitle());
         if ($overview->get('body')->summary) {
           $event->setLede([

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -30,14 +30,16 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       $event->getEntity()->bundle() == 'localgov_guides_page' &&
       $event->getEntity()->localgov_guides_parent
     ) {
-      $overview = $event->getEntity()->localgov_guides_parent->entity;
-      $event->setTitle($overview->getTitle());
-      if ($overview->get('body')->summary) {
-        $event->setLede([
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $overview->get('body')->summary,
-        ]);
+      $overview = $event->getEntity()->localgov_guides_parent->getEntity();
+      if (!empty($overview) {
+        $event->setTitle($overview->getTitle());
+        if ($overview->get('body')->summary) {
+          $event->setLede([
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $overview->get('body')->summary,
+          ]);
+        }
       }
       else {
         $event->setLede('');


### PR DESCRIPTION
Fix #28 by adding using getEntity() to load the overview rather than the magic method.
Adds a condition that the overview is not empty to protect for future issues.