### PR TITLE
Add test for the guides block

### DIFF
--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -28,9 +28,9 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
   public function setPageHeader(PageHeaderDisplayEvent $event) {
     if ($event->getEntity() instanceof Node &&
       $event->getEntity()->bundle() == 'localgov_guides_page' &&
-      $event->getEntity()->localgov_guides_parent
+      $event->getEntity()->localgov_guides_parent->entity
     ) {
-      $overview = $event->getEntity()->localgov_guides_parent->getEntity();
+      $overview = $event->getEntity()->localgov_guides_parent->entity;
       if (!empty($overview)) {
         $event->setTitle($overview->getTitle());
         if ($overview->get('body')->summary) {

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -31,7 +31,7 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       $event->getEntity()->localgov_guides_parent
     ) {
       $overview = $event->getEntity()->localgov_guides_parent->getEntity();
-      if (!empty($overview) {
+      if (!empty($overview)) {
         $event->setTitle($overview->getTitle());
         if ($overview->get('body')->summary) {
           $event->setLede([

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -30,14 +30,16 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       $event->getEntity()->bundle() == 'localgov_guides_page' &&
       $event->getEntity()->localgov_guides_parent
     ) {
-      $overview = $event->getEntity()->localgov_guides_parent->entity;
-      $event->setTitle($overview->getTitle());
-      if ($overview->get('body')->summary) {
-        $event->setLede([
-          '#type' => 'html_tag',
-          '#tag' => 'p',
-          '#value' => $overview->get('body')->summary,
-        ]);
+      $overview = $event->getEntity()->localgov_guides_parent->getEntity();
+      if (!empty($overview) {
+        $event->setTitle($overview->getTitle());
+        if ($overview->get('body')->summary) {
+          $event->setLede([
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $overview->get('body')->summary,
+          ]);
+        }
       }
       else {
         $event->setLede('');

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -91,4 +91,5 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $this->assertSession()->responseNotContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertSession()->responseContains('<h1 class="header">' . $orphan_title . '</h1>');
   }
+
 }

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\Tests\localgov_guides\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests page header block.
+ *
+ * @group localgov_guides
+ */
+class PageHeaderBlockTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'block',
+    'path',
+    'options',
+    'localgov_guides',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'classy';
+
+  /**
+   * A user with the 'administer blocks' permission.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->adminUser = $this->drupalCreateUser(['administer blocks']);
+    $this->drupalLogin($this->adminUser);
+    $this->drupalPlaceBlock('localgov_page_header_block');
+    $this->drupalLogout($this->adminUser);
+  }
+
+  /**
+   * Tests that the page header block displays the overview title.
+   *
+   * This applies to Guide overview pages and Guide pages that are part of a
+   * guide, with the fallback to the guide page title if no parent.
+   */
+  public function testGuidePageHeaderBlock() {
+    $overview_title = 'Guide overview - ' . $this->randomMachineName(8);
+    $overview = $this->createNode([
+      'title' => $overview_title,
+      'type' => 'localgov_guides_overview',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $page_title = 'Guide page - ' . $this->randomMachineName(8);
+    $page = $this->createNode([
+      'title' => $page_title,
+      'type' => 'localgov_guides_page',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_guides_parent' => ['target_id' => $overview->id()],
+    ]);
+
+    $orphan_title = 'Guide page - ' . $this->randomMachineName(8);
+    $orphan = $this->createNode([
+      'title' => $orphan_title,
+      'type' => 'localgov_guides_page',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->drupalGet($overview->toUrl()->toString());
+    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
+
+    $this->drupalGet($page->toUrl()->toString());
+    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertNoRaw('<h1 class="header">' . $page_title . '</h1>');
+
+    $this->drupalGet($orphan->toUrl()->toString());
+    $this->assertNoRaw('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertRaw('<h1 class="header">' . $orphan_title . '</h1>');
+  }
+}

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -81,14 +81,14 @@ class PageHeaderBlockTest extends BrowserTestBase {
     ]);
 
     $this->drupalGet($overview->toUrl()->toString());
-    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
 
     $this->drupalGet($page->toUrl()->toString());
-    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
-    $this->assertNoRaw('<h1 class="header">' . $page_title . '</h1>');
+    $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertSession()->responseNotContains('<h1 class="header">' . $page_title . '</h1>');
 
     $this->drupalGet($orphan->toUrl()->toString());
-    $this->assertNoRaw('<h1 class="header">' . $overview_title . '</h1>');
-    $this->assertRaw('<h1 class="header">' . $orphan_title . '</h1>');
+    $this->assertSession()->responseNotContains('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertSession()->responseContains('<h1 class="header">' . $orphan_title . '</h1>');
   }
 }


### PR DESCRIPTION
Add a test to the guide page header block.
Verifies that the guide overview is always used as the page title.
This incorporates #29, and adds the test.