### PR TITLE
Use the dedicated guide description field as the lede in the page header block

### DIFF
--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -26,6 +26,21 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
    * Set page title and lede.
    */
   public function setPageHeader(PageHeaderDisplayEvent $event) {
+
+    // Guide overview.
+    if ($event->getEntity() instanceof Node &&
+      $event->getEntity()->bundle() == 'localgov_guides_overview'
+    ) {
+      if ($event->getEntity()->get('localgov_guides_description')->value) {
+        $event->setLede([
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $event->getEntity()->get('localgov_guides_description')->value,
+        ]);
+      }
+    }
+
+    // Guide page.
     if ($event->getEntity() instanceof Node &&
       $event->getEntity()->bundle() == 'localgov_guides_page' &&
       $event->getEntity()->localgov_guides_parent->entity
@@ -33,11 +48,11 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       $overview = $event->getEntity()->localgov_guides_parent->entity;
       if (!empty($overview)) {
         $event->setTitle($overview->getTitle());
-        if ($overview->get('body')->summary) {
+        if ($overview->get('localgov_guides_description')->value) {
           $event->setLede([
             '#type' => 'html_tag',
             '#tag' => 'p',
-            '#value' => $overview->get('body')->summary,
+            '#value' => $overview->get('localgov_guides_description')->value,
           ]);
         }
       }

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -87,34 +87,19 @@ class PageHeaderBlockTest extends BrowserTestBase {
     ]);
 
     $this->drupalGet($overview->toUrl()->toString());
-<<<<<<< HEAD
     $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
-    $this->assertRaw('<div class="subheader">' . $overview_lede . '</div>');
+    $this->assertSession()->responseContains('<p>' . $orphan_summary . '</p>');
 
     $this->drupalGet($page->toUrl()->toString());
     $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertSession()->responseNotContains('<h1 class="header">' . $page_title . '</h1>');
-    $this->assertRaw('<div class="subheader">' . $overview_lede . '</div>');
-    $this->assertNoRaw('<div class="subheader">' . $page_summary . '</div>');
+    $this->assertSession()->responseContains('<p>' . $overview_lede . '</p>');
+    $this->assertSession()->responseNotContains('<p>' . $page_summary . '</p>');
 
     $this->drupalGet($orphan->toUrl()->toString());
     $this->assertSession()->responseNotContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertSession()->responseContains('<h1 class="header">' . $orphan_title . '</h1>');
-    $this->assertRaw('<div class="subheader">' . $orphan_summary . '</div>');
-=======
-    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
-    $this->assertRaw('<p>' . $overview_lede . '</p>');
-
-    $this->drupalGet($page->toUrl()->toString());
-    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
-    $this->assertNoRaw('<h1 class="header">' . $page_title . '</h1>');
-    $this->assertRaw('<p>' . $overview_lede . '</p>');
-    $this->assertNoRaw('<p>' . $page_summary . '</p>');
-
-    $this->drupalGet($orphan->toUrl()->toString());
-    $this->assertRaw('<h1 class="header">' . $orphan_title . '</h1>');
-    $this->assertRaw('<p>' . $orphan_summary . '</p>');
->>>>>>> 9e8f0c7... Use the guide overview description field for the guide lede
+    $this->assertSession()->responseContains('<p>' . $orphan_summary . '</p>');
   }
 
 }

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -59,37 +59,47 @@ class PageHeaderBlockTest extends BrowserTestBase {
    */
   public function testGuidePageHeaderBlock() {
     $overview_title = 'Guide overview - ' . $this->randomMachineName(8);
+    $overview_lede = 'Guide overview summary - ' .  $this->randomMachineName(8);
     $overview = $this->createNode([
       'title' => $overview_title,
+      'localgov_guides_description' => $overview_lede,
       'type' => 'localgov_guides_overview',
       'status' => NodeInterface::PUBLISHED,
     ]);
 
     $page_title = 'Guide page - ' . $this->randomMachineName(8);
+    $page_summary = 'Guide page summary - ' . $this->randomMachineName(8);
     $page = $this->createNode([
       'title' => $page_title,
+      'summary' => $page_summary,
       'type' => 'localgov_guides_page',
       'status' => NodeInterface::PUBLISHED,
       'localgov_guides_parent' => ['target_id' => $overview->id()],
     ]);
 
     $orphan_title = 'Guide page - ' . $this->randomMachineName(8);
+    $orphan_summary = 'Guide orphan summary - ' . $this->randomMachineName(8);
     $orphan = $this->createNode([
       'title' => $orphan_title,
+      'summary' => $orphan_summary,
       'type' => 'localgov_guides_page',
       'status' => NodeInterface::PUBLISHED,
     ]);
 
     $this->drupalGet($overview->toUrl()->toString());
     $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertRaw('<div class="subheader">' . $overview_lede . '</div>');
 
     $this->drupalGet($page->toUrl()->toString());
     $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertSession()->responseNotContains('<h1 class="header">' . $page_title . '</h1>');
+    $this->assertRaw('<div class="subheader">' . $overview_lede . '</div>');
+    $this->assertNoRaw('<div class="subheader">' . $page_summary . '</div>');
 
     $this->drupalGet($orphan->toUrl()->toString());
     $this->assertSession()->responseNotContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertSession()->responseContains('<h1 class="header">' . $orphan_title . '</h1>');
+    $this->assertRaw('<div class="subheader">' . $orphan_summary . '</div>');
   }
 
 }

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -71,7 +71,7 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $page_summary = 'Guide page summary - ' . $this->randomMachineName(8);
     $page = $this->createNode([
       'title' => $page_title,
-      'summary' => $page_summary,
+      'body' => ['value' => $page_summary . ' - body', 'summary' => $page_summary],
       'type' => 'localgov_guides_page',
       'status' => NodeInterface::PUBLISHED,
       'localgov_guides_parent' => ['target_id' => $overview->id()],
@@ -81,12 +81,13 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $orphan_summary = 'Guide orphan summary - ' . $this->randomMachineName(8);
     $orphan = $this->createNode([
       'title' => $orphan_title,
-      'summary' => $orphan_summary,
+      'body' => ['value' => $orphan_summary . ' - body', 'summary' => $orphan_summary],
       'type' => 'localgov_guides_page',
       'status' => NodeInterface::PUBLISHED,
     ]);
 
     $this->drupalGet($overview->toUrl()->toString());
+<<<<<<< HEAD
     $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertRaw('<div class="subheader">' . $overview_lede . '</div>');
 
@@ -100,6 +101,20 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $this->assertSession()->responseNotContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertSession()->responseContains('<h1 class="header">' . $orphan_title . '</h1>');
     $this->assertRaw('<div class="subheader">' . $orphan_summary . '</div>');
+=======
+    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertRaw('<p>' . $overview_lede . '</p>');
+
+    $this->drupalGet($page->toUrl()->toString());
+    $this->assertRaw('<h1 class="header">' . $overview_title . '</h1>');
+    $this->assertNoRaw('<h1 class="header">' . $page_title . '</h1>');
+    $this->assertRaw('<p>' . $overview_lede . '</p>');
+    $this->assertNoRaw('<p>' . $page_summary . '</p>');
+
+    $this->drupalGet($orphan->toUrl()->toString());
+    $this->assertRaw('<h1 class="header">' . $orphan_title . '</h1>');
+    $this->assertRaw('<p>' . $orphan_summary . '</p>');
+>>>>>>> 9e8f0c7... Use the guide overview description field for the guide lede
   }
 
 }

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -59,7 +59,7 @@ class PageHeaderBlockTest extends BrowserTestBase {
    */
   public function testGuidePageHeaderBlock() {
     $overview_title = 'Guide overview - ' . $this->randomMachineName(8);
-    $overview_lede = 'Guide overview summary - ' .  $this->randomMachineName(8);
+    $overview_lede = 'Guide overview summary - ' . $this->randomMachineName(8);
     $overview = $this->createNode([
       'title' => $overview_title,
       'localgov_guides_description' => $overview_lede,

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -88,7 +88,7 @@ class PageHeaderBlockTest extends BrowserTestBase {
 
     $this->drupalGet($overview->toUrl()->toString());
     $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');
-    $this->assertSession()->responseContains('<p>' . $orphan_summary . '</p>');
+    $this->assertSession()->responseContains('<p>' . $overview_lede . '</p>');
 
     $this->drupalGet($page->toUrl()->toString());
     $this->assertSession()->responseContains('<h1 class="header">' . $overview_title . '</h1>');


### PR DESCRIPTION
Fix #33.

See issue there before merging, as this might not be the right solution, and it may be prefferable to delete the dedicated description field.