### PR TITLE
Fixed failing tests for Drupal 9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test LocalGov Drupal
+name: Test LocalGov Drupal Guides
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test LocalGovDrupal Guides
+name: Test LocalGov Drupal
 
 on:
   push:
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       - name: Clone drupal_container
         uses: actions/checkout@v2
         with:

--- a/tests/src/Functional/ContentsBlockTest.php
+++ b/tests/src/Functional/ContentsBlockTest.php
@@ -20,7 +20,7 @@ class ContentsBlockTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'block',
     'path',
     'options',
@@ -42,7 +42,7 @@ class ContentsBlockTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser(['administer blocks']);
@@ -110,29 +110,29 @@ class ContentsBlockTest extends BrowserTestBase {
     $this->drupalGet($overview->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(4, count($results));
-    $this->assertContains('Guide overview', $results[0]->getText());
-    $this->assertNotContains($overview->toUrl()->toString(), $results[0]->getHtml());
-    $this->assertContains('Guide page 0', $results[1]->getText());
-    $this->assertContains($pages[0]->toUrl()->toString(), $results[1]->getHtml());
-    $this->assertContains('Guide page 1', $results[2]->getText());
-    $this->assertContains($pages[1]->toUrl()->toString(), $results[2]->getHtml());
-    $this->assertContains('Guide page 2', $results[3]->getText());
-    $this->assertContains($pages[2]->toUrl()->toString(), $results[3]->getHtml());
+    $this->assertCount(4, $results);
+    $this->assertStringContainsString('Guide overview', $results[0]->getText());
+    $this->assertStringNotContainsString($overview->toUrl()->toString(), $results[0]->getHtml());
+    $this->assertStringContainsString('Guide page 0', $results[1]->getText());
+    $this->assertStringContainsString($pages[0]->toUrl()->toString(), $results[1]->getHtml());
+    $this->assertStringContainsString('Guide page 1', $results[2]->getText());
+    $this->assertStringContainsString($pages[1]->toUrl()->toString(), $results[2]->getHtml());
+    $this->assertStringContainsString('Guide page 2', $results[3]->getText());
+    $this->assertStringContainsString($pages[2]->toUrl()->toString(), $results[3]->getHtml());
 
     // Check page.
     $this->drupalGet($pages[0]->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(4, count($results));
-    $this->assertContains('Guide overview', $results[0]->getText());
-    $this->assertContains($overview->toUrl()->toString(), $results[0]->getHtml());
-    $this->assertContains('Guide page 0', $results[1]->getText());
-    $this->assertNotContains($pages[0]->toUrl()->toString(), $results[1]->getHtml());
-    $this->assertContains('Guide page 1', $results[2]->getText());
-    $this->assertContains($pages[1]->toUrl()->toString(), $results[2]->getHtml());
-    $this->assertContains('Guide page 2', $results[3]->getText());
-    $this->assertContains($pages[2]->toUrl()->toString(), $results[3]->getHtml());
+    $this->assertCount(4, $results);
+    $this->assertStringContainsString('Guide overview', $results[0]->getText());
+    $this->assertStringContainsString($overview->toUrl()->toString(), $results[0]->getHtml());
+    $this->assertStringContainsString('Guide page 0', $results[1]->getText());
+    $this->assertStringNotContainsString($pages[0]->toUrl()->toString(), $results[1]->getHtml());
+    $this->assertStringContainsString('Guide page 1', $results[2]->getText());
+    $this->assertStringContainsString($pages[1]->toUrl()->toString(), $results[2]->getHtml());
+    $this->assertStringContainsString('Guide page 2', $results[3]->getText());
+    $this->assertStringContainsString($pages[2]->toUrl()->toString(), $results[3]->getHtml());
 
     // Check caching.
     $pages[] = $this->createNode([
@@ -144,14 +144,14 @@ class ContentsBlockTest extends BrowserTestBase {
     $this->drupalGet($overview->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(5, count($results));
-    $this->assertText('Guide page 3');
+    $this->assertCount(5, $results);
+    $this->assertSession()->responseContains('Guide page 3');
     // Change title.
     $pages[2]->title = 'New title page 2';
     $pages[2]->save();
     $this->drupalGet($overview->toUrl()->toString());
-    $this->assertNoText('Guide page 2');
-    $this->assertText('New title page 2');
+    $this->assertSession()->responseNotContains('Guide page 2');
+    $this->assertSession()->responseContains('New title page 2');
 
     // Another overview.
     $overview_2 = $this->createNode([
@@ -167,17 +167,17 @@ class ContentsBlockTest extends BrowserTestBase {
     $this->drupalGet($overview->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(4, count($results));
-    $this->assertNotContains('Guide page 0', $results[1]->getText());
+    $this->assertCount(4, $results);
+    $this->assertStringNotContainsString('Guide page 0', $results[1]->getText());
     // Check new overview.
     $this->drupalGet($overview_2->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(2, count($results));
-    $this->assertContains('Guide overview', $results[0]->getText());
-    $this->assertNotContains($overview_2->toUrl()->toString(), $results[0]->getHtml());
-    $this->assertContains('Guide page 0', $results[1]->getText());
-    $this->assertContains($pages[0]->toUrl()->toString(), $results[1]->getHtml());
+    $this->assertCount(2, $results);
+    $this->assertStringContainsString('Guide overview', $results[0]->getText());
+    $this->assertStringNotContainsString($overview_2->toUrl()->toString(), $results[0]->getHtml());
+    $this->assertStringContainsString('Guide page 0', $results[1]->getText());
+    $this->assertStringContainsString($pages[0]->toUrl()->toString(), $results[1]->getHtml());
 
     // Unpublish a page.
     $pages[1]->status = NodeInterface::NOT_PUBLISHED;
@@ -188,23 +188,23 @@ class ContentsBlockTest extends BrowserTestBase {
     $this->drupalGet($overview->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(4, count($results));
-    $this->assertText('Guide page 1');
+    $this->assertCount(4, $results);
+    $this->assertSession()->responseContains('Guide page 1');
     $this->drupalLogout();
     // But not for anon.
     $this->drupalGet($overview->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(3, count($results));
-    $this->assertNoText('Guide page 1');
+    $this->assertCount(3, $results);
+    $this->assertSession()->responseNotContains('Guide page 1');
 
     // Delete page.
     $pages[3]->delete();
     $this->drupalGet($overview->toUrl()->toString());
     $xpath = '//ul[@class="progress"]/li';
     $results = $this->xpath($xpath);
-    $this->assertEquals(2, count($results));
-    $this->assertNoText('Guide page 3');
+    $this->assertCount(2, $results);
+    $this->assertSession()->responseNotContains('Guide page 3');
   }
 
 }

--- a/tests/src/Functional/GuidePagesTest.php
+++ b/tests/src/Functional/GuidePagesTest.php
@@ -42,7 +42,7 @@ class GuidePagesTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_core',
     'localgov_guides',
     'field_ui',
@@ -51,7 +51,7 @@ class GuidePagesTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser([

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -20,7 +20,7 @@ class PageHeaderBlockTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'block',
     'path',
     'options',
@@ -42,7 +42,7 @@ class PageHeaderBlockTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser(['administer blocks']);

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -46,7 +46,7 @@ class PagesIntegrationTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_core',
     'localgov_services_landing',
     'localgov_services_sublanding',
@@ -58,7 +58,7 @@ class PagesIntegrationTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser(['bypass node access', 'administer nodes']);

--- a/tests/src/Functional/PrevNextBlockTest.php
+++ b/tests/src/Functional/PrevNextBlockTest.php
@@ -20,7 +20,7 @@ class PrevNextBlockTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'block',
     'path',
     'options',
@@ -42,7 +42,7 @@ class PrevNextBlockTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser(['administer blocks']);


### PR DESCRIPTION
Fixes failing PHPUnit tests when running Drupal 9. Includes fixes for code deprecation warnings as well.

Closes #42 