### PR TITLE
Fix prev / next unpublish #44

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "localgovdrupal/localgov_core": "dev-master"
+    "localgovdrupal/localgov_core": "^1.0@alpha"
   },
   "require-dev": {
-    "localgovdrupal/localgov_services": "dev-master",
-    "localgovdrupal/localgov_topics": "dev-master",
+    "localgovdrupal/localgov_services": "^1.0@alpha",
+    "localgovdrupal/localgov_topics": "^1.0@alpha",
     "drupal/pathauto": "^1.6"
   }
 }

--- a/src/Plugin/Block/GuidesAbstractBaseBlock.php
+++ b/src/Plugin/Block/GuidesAbstractBaseBlock.php
@@ -128,7 +128,7 @@ abstract class GuidesAbstractBaseBlock extends BlockBase implements ContainerFac
    * {@inheritdoc}
    */
   public function getCacheContexts() {
-    return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
+    return Cache::mergeContexts(parent::getCacheContexts(), ['user', 'route']);
   }
 
   /**

--- a/src/Plugin/Block/GuidesAbstractBaseBlock.php
+++ b/src/Plugin/Block/GuidesAbstractBaseBlock.php
@@ -103,6 +103,10 @@ abstract class GuidesAbstractBaseBlock extends BlockBase implements ContainerFac
       }
 
       $this->guidePages = $this->overview->localgov_guides_pages->referencedEntities();
+      $this->guidePages = array_filter($this->guidePages, function ($guide_node) {
+        return ($guide_node instanceof NodeInterface) && $guide_node->access('view');
+      });
+      $this->guidePages = array_values($this->guidePages);
       $this->format = $this->overview->localgov_guides_list_format->value;
     }
   }

--- a/src/Plugin/Block/GuidesContentsBlock.php
+++ b/src/Plugin/Block/GuidesContentsBlock.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\localgov_guides\Plugin\Block;
 
-use Drupal\node\NodeInterface;
-
 /**
  * Guide contents block.
  *

--- a/src/Plugin/Block/GuidesContentsBlock.php
+++ b/src/Plugin/Block/GuidesContentsBlock.php
@@ -26,11 +26,8 @@ class GuidesContentsBlock extends GuidesAbstractBaseBlock {
     $options = $this->node->id() == $this->overview->id() ? ['attributes' => ['class' => 'active']] : [];
     $links[] = $this->overview->toLink($this->overview->localgov_guides_section_title->value, 'canonical', $options);
     foreach ($this->guidePages as $guide_node) {
-      assert($guide_node instanceof NodeInterface);
-      if ($guide_node->access('view')) {
-        $options = $this->node->id() == $guide_node->id() ? ['attributes' => ['class' => 'active']] : [];
-        $links[] = $guide_node->toLink($guide_node->localgov_guides_section_title->value, 'canonical', $options);
-      }
+      $options = $this->node->id() == $guide_node->id() ? ['attributes' => ['class' => 'active']] : [];
+      $links[] = $guide_node->toLink($guide_node->localgov_guides_section_title->value, 'canonical', $options);
     }
 
     $build = [];

--- a/src/Plugin/Block/GuidesPrevNextBlock.php
+++ b/src/Plugin/Block/GuidesPrevNextBlock.php
@@ -28,22 +28,18 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
     }
 
     if ($this->node->bundle() == 'localgov_guides_page') {
-      $page_delta = array_search(['target_id' => $this->node->id()], $this->overview->localgov_guides_pages->getValue());
+      $page_delta = array_search($this->node, $this->guidePages);
       if (!empty($this->guidePages[$page_delta - 1])) {
-        if ($this->guidePages[$page_delta - 1]->access('view')) {
-          $previous_url = $this->guidePages[$page_delta - 1]->toUrl();
-          $previous_title = $this->guidePages[$page_delta - 1]->title->value;
-        }
+        $previous_url = $this->guidePages[$page_delta - 1]->toUrl();
+        $previous_title = $this->guidePages[$page_delta - 1]->title->value;
       }
       else {
         $previous_url = $this->overview->toUrl();
         $previous_title = $this->overview->localgov_guides_section_title->value;
       }
       if (!empty($this->guidePages[$page_delta + 1])) {
-        if ($this->guidePages[$page_delta + 1]->access('view')) {
-          $next_url = $this->guidePages[$page_delta + 1]->toUrl();
-          $next_title = $this->guidePages[$page_delta + 1]->title->value;
-        }
+        $next_url = $this->guidePages[$page_delta + 1]->toUrl();
+        $next_title = $this->guidePages[$page_delta + 1]->title->value;
       }
     }
 

--- a/tests/src/Functional/PrevNextBlockTest.php
+++ b/tests/src/Functional/PrevNextBlockTest.php
@@ -95,6 +95,39 @@ class PrevNextBlockTest extends BrowserTestBase {
     $this->assertSession()->responseContains($pages[1]->toUrl()->toString());
     $this->assertSession()->pageTextNotContains('Next');
 
+    // Unpublish a page.
+    $pages[1]->status = NodeInterface::NOT_PUBLISHED;
+    $pages[1]->save();
+    // Still linked.
+    $content_admin = $this->drupalCreateUser(['bypass node access']);
+    $this->drupalLogin($content_admin);
+    $this->drupalGet($pages[0]->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Prev');
+    $this->assertSession()->responseContains($overview->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Next');
+    $this->assertSession()->responseContains($pages[1]->toUrl()->toString());
+    $this->drupalGet($pages[1]->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Prev');
+    $this->assertSession()->responseContains($pages[0]->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Next');
+    $this->assertSession()->responseContains($pages[2]->toUrl()->toString());
+    $this->drupalGet($pages[2]->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Prev');
+    $this->assertSession()->responseContains($pages[1]->toUrl()->toString());
+    $this->assertSession()->pageTextNotContains('Next');
+    $this->drupalLogout();
+    // But not for anon.
+    $this->drupalGet($pages[0]->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Prev');
+    $this->assertSession()->responseContains($overview->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Next');
+    $this->assertSession()->responseContains($pages[2]->toUrl()->toString());
+    $this->drupalGet($pages[2]->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Prev');
+    $this->assertSession()->responseContains($pages[0]->toUrl()->toString());
+    $this->assertSession()->pageTextNotContains('Next');
+    $this->drupalLogout();
+
     // Check deleting page.
     // Following test will fail because of reliance on deltas:
     // https://github.com/localgovdrupal/localgov_guides/issues/6#issuecomment-644155487

--- a/tests/src/Functional/PrevNextBlockTest.php
+++ b/tests/src/Functional/PrevNextBlockTest.php
@@ -126,7 +126,6 @@ class PrevNextBlockTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains('Prev');
     $this->assertSession()->responseContains($pages[0]->toUrl()->toString());
     $this->assertSession()->pageTextNotContains('Next');
-    $this->drupalLogout();
 
     // Check deleting page.
     // Following test will fail because of reliance on deltas:


### PR DESCRIPTION
Fixes #44 

#45 wouldn't show a prev/next if an adjacent page was unpublished. By moving the view access logic to the base block class the list of available pages is calculated for both blocks and the prev next can use the same calculation.