### PR TITLE
Deleted guide pages

### DIFF
--- a/tests/src/Functional/PrevNextBlockTest.php
+++ b/tests/src/Functional/PrevNextBlockTest.php
@@ -126,21 +126,21 @@ class PrevNextBlockTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains('Prev');
     $this->assertSession()->responseContains($pages[0]->toUrl()->toString());
     $this->assertSession()->pageTextNotContains('Next');
+    // Republish for next tests.
+    $pages[1]->status = NodeInterface::PUBLISHED;
+    $pages[1]->save();
 
     // Check deleting page.
-    // Following test will fail because of reliance on deltas:
-    // https://github.com/localgovdrupal/localgov_guides/issues/6#issuecomment-644155487
-    // @codingStandardsIgnoreStart
-    // $pages[0]->delete();
-    // $this->drupalGet($overview->toUrl()->toString());
-    // $this->assertSession()->pageTextNotContains('Prev');
-    // $this->assertSession()->pageTextContains('Next');
-    // $this->assertSession()->responseContains($pages[1]->toUrl()->toString());
-    // $this->drupalGet($pages[1]->toUrl()->toString());
-    // $this->assertSession()->pageTextContains('Prev');
-    // $this->assertSession()->responseContains($overview->toUrl()->toString());
-    // $this->assertSession()->pageTextContains('Next');
-    // $this->assertSession()->responseContains($pages[2]->toUrl()->toString());
+    $pages[0]->delete();
+    $this->drupalGet($overview->toUrl()->toString());
+    $this->assertSession()->pageTextNotContains('Prev');
+    $this->assertSession()->pageTextContains('Next');
+    $this->assertSession()->responseContains($pages[1]->toUrl()->toString());
+    $this->drupalGet($pages[1]->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Prev');
+    $this->assertSession()->responseContains($overview->toUrl()->toString());
+    $this->assertSession()->pageTextContains('Next');
+    $this->assertSession()->responseContains($pages[2]->toUrl()->toString());
   }
 
 }


### PR DESCRIPTION
Uncomment (now already passing test) for #31

MR #47 for issue #44 incidentally also fixed calling deleted entity
references in the 'drupal way'™ by checking that they exist before
calling them. The module does however already provide update hooks for
pages, as described in #6 and mentioned in https://github.com/localgovdrupal/localgov_guides/issues/31#issuecomment-828410428
so completism we should also make a hook_delete to remove them from the
references?