### PR TITLE
Localgov composer dependencies to non-alpha.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "localgovdrupal/localgov_core": "^1.0@alpha"
+    "localgovdrupal/localgov_core": "^1.0"
   },
   "require-dev": {
-    "localgovdrupal/localgov_services": "^1.0@alpha",
-    "localgovdrupal/localgov_topics": "^1.0@alpha",
+    "localgovdrupal/localgov_services": "^1.0",
+    "localgovdrupal/localgov_topics": "^1.0",
     "drupal/pathauto": "^1.6"
   }
 }


### PR DESCRIPTION
Further to localgovdrupal/localgov#200 tidy up composer dependencies to the now existing 1.x versions.