### PR TITLE
Remove dashes option from Guide Overview list format field

### DIFF
--- a/config/install/field.storage.node.localgov_guides_list_format.yml
+++ b/config/install/field.storage.node.localgov_guides_list_format.yml
@@ -16,9 +16,6 @@ settings:
     -
       value: ordered
       label: 'Progress: Numbers'
-    -
-      value: dashes
-      label: 'List: Dashes'
   allowed_values_function: ''
 module: options
 locked: false

--- a/templates/guides-contents-block.html.twig
+++ b/templates/guides-contents-block.html.twig
@@ -8,34 +8,18 @@
 <nav class="cta">
   {% if format == 'ordered' %}
     <ol class="progress">
-  {% elseif format == 'unordered' %}
-    <ul class="progress">
-  {% elseif format == 'dashes' %}
-    <ul class="guide-dashes">
   {% else %}
     <ul class="progress">
   {% endif %}
     {% for link in links %}
-      {% if format == 'dashes' %}
-        {% if link.url.options.attributes.class == 'active' %}
-          <li> {{ link.text }} </li>
-        {% else %}
-          <li> {{ link }} </li>
-        {% endif %}
+      {% if link.url.options.attributes.class == 'active' %}
+        <li><span aria-current="page" class="progress--step progress--active"></span> {{ link.text }} </li>
       {% else %}
-        {% if link.url.options.attributes.class == 'active' %}
-          <li><span aria-current="page" class="progress--step progress--active"></span> {{ link.text }} </li>
-        {% else %}
-          <li><span class="progress--step"></span> {{ link }} </li>
-        {% endif %}
+        <li><span class="progress--step"></span> {{ link }} </li>
       {% endif %}
     {% endfor %}
   {% if format == 'ordered' %}
     </ol>
-  {% elseif format == 'unordered' %}
-    </ul>
-  {% elseif format == 'dashes' %}
-    </ul>
   {% else %}
     </ul>
   {% endif %}


### PR DESCRIPTION
Closes #61 

This PR:

- Removes the option to select 'Dashes' as the list format for a Guide Overview
- Defaults list format to bullets unless the list format is set to 'Numbers'. 