### PR TITLE
Add label and class to unpublished guide titles in guide contents block

### DIFF
--- a/src/Plugin/Block/GuidesContentsBlock.php
+++ b/src/Plugin/Block/GuidesContentsBlock.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\localgov_guides\Plugin\Block;
 
-use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
@@ -15,7 +14,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  *   admin_label = "Guide contents"
  * )
  */
-class GuidesContentsBlock extends GuidesAbstractBaseBlock implements ContainerInjectionInterface {
+class GuidesContentsBlock extends GuidesAbstractBaseBlock {
 
   use StringTranslationTrait;
 

--- a/src/Plugin/Block/GuidesContentsBlock.php
+++ b/src/Plugin/Block/GuidesContentsBlock.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\localgov_guides\Plugin\Block;
 
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
 /**
  * Guide contents block.
  *
@@ -12,7 +15,9 @@ namespace Drupal\localgov_guides\Plugin\Block;
  *   admin_label = "Guide contents"
  * )
  */
-class GuidesContentsBlock extends GuidesAbstractBaseBlock {
+class GuidesContentsBlock extends GuidesAbstractBaseBlock implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
 
   /**
    * {@inheritdoc}
@@ -20,11 +25,23 @@ class GuidesContentsBlock extends GuidesAbstractBaseBlock {
   public function build() {
     $this->setPages();
     $links = [];
+    $overviewOptions = [];
 
-    $options = $this->node->id() == $this->overview->id() ? ['attributes' => ['class' => 'active']] : [];
-    $links[] = $this->overview->toLink($this->overview->localgov_guides_section_title->value, 'canonical', $options);
+    if ($this->node->id() == $this->overview->id()) {
+      $overviewOptions = ['attributes' => ['class' => 'active']];
+      if (!$this->node->isPublished()) {
+        $this->overview->localgov_guides_section_title->value .= ' ' . $this->t('(Unpublished)');
+        $overviewOptions['attributes']['class'] = trim($overviewOptions['attributes']['class'] . ' unpublished');
+      }
+    }
+    $links[] = $this->overview->toLink($this->overview->localgov_guides_section_title->value, 'canonical', $overviewOptions);
+
     foreach ($this->guidePages as $guide_node) {
       $options = $this->node->id() == $guide_node->id() ? ['attributes' => ['class' => 'active']] : [];
+      if (!$guide_node->isPublished()) {
+        $guide_node->localgov_guides_section_title->value .= ' ' . $this->t('(Unpublished)');
+        $options['attributes']['class'] = trim($options['attributes']['class'] . ' unpublished');
+      }
       $links[] = $guide_node->toLink($guide_node->localgov_guides_section_title->value, 'canonical', $options);
     }
 

--- a/templates/guides-contents-block.html.twig
+++ b/templates/guides-contents-block.html.twig
@@ -12,7 +12,7 @@
     <ul class="progress">
   {% endif %}
     {% for link in links %}
-      {% if link.url.options.attributes.class == 'active' %}
+      {% if 'active' in link.url.options.attributes.class %}
         <li><span aria-current="page" class="progress--step progress--active"></span> {{ link.text }} </li>
       {% else %}
         <li><span class="progress--step"></span> {{ link }} </li>


### PR DESCRIPTION
Closes localgovdrupal/localgov_base#465, this PR:

- Adds the text ' (Unpublished)' to unpublished guide titles in the guide contents block
- Adds the class `unpublished` to unpublished guide title links in the guide contents block

This assists content editors in recognising guide pages that appear in nav but aren't published.

A further PR for the localgov_base theme will extend BEM classes to allow styling of active **and** linked unpublished guide titles based on the presence of the `unpublished` class.