### PR TITLE
Make strings in templates translatable.

### DIFF
--- a/templates/guides-prev-next-block.html.twig
+++ b/templates/guides-prev-next-block.html.twig
@@ -5,6 +5,6 @@
 */
 #}
 <nav class="localgov_guides--navigation">
-  {% if previous_url %}<a href="{{ previous_url }}" class="btn btn-carbon localgov_guides--previous" aria-label="Previous: {{ previous_title }}"><span class="fa fa-chevron-left"></span>Previous</a>{% endif %}
-  {% if next_url %}<a href="{{ next_url }}" class="btn btn-primary localgov_guides--next" aria-label="Next: {{ next_title }}"><span class="fa fa-chevron-right"></span>Next</a>{% endif %}
+  {% if previous_url %}<a href="{{ previous_url }}" class="btn btn-carbon localgov_guides--previous" aria-label="{{ 'Previous'|t }}: {{ previous_title }}"><span class="fa fa-chevron-left"></span>{{ 'Previous'|t }}</a>{% endif %}
+  {% if next_url %}<a href="{{ next_url }}" class="btn btn-primary localgov_guides--next" aria-label="{{ 'Next'|t }}: {{ next_title }}"><span class="fa fa-chevron-right"></span>{{ 'Next'|t }}</a>{% endif %}
 </nav>

--- a/templates/node--localgov-guides-overview--full.html.twig
+++ b/templates/node--localgov-guides-overview--full.html.twig
@@ -17,6 +17,6 @@
   ]
 %}
 <article{{ attributes.addClass(classes) }}>
-  <h2>Overview</h2>
+  <h2>{{ 'Overview'|t }}</h2>
   {{ content }}
 </article>


### PR DESCRIPTION
Answering a question in slack: if the title 'Overview' could be changed. I noticed that the strings in the templates aren't translatable. So small patch to wrap them in twig translates.