### PR TITLE
#87: Fixed PHP 8 'Fatal error: Nesting level too deep', by enforcing …

### DIFF
--- a/src/Plugin/Block/GuidesPrevNextBlock.php
+++ b/src/Plugin/Block/GuidesPrevNextBlock.php
@@ -28,7 +28,7 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
     }
 
     if ($this->node->bundle() == 'localgov_guides_page') {
-      $page_delta = array_search($this->node, $this->guidePages);
+      $page_delta = array_search($this->node, $this->guidePages, TRUE);
       if (!empty($this->guidePages[$page_delta - 1])) {
         $previous_url = $this->guidePages[$page_delta - 1]->toUrl();
         $previous_title = $this->guidePages[$page_delta - 1]->title->value;


### PR DESCRIPTION
See related issue: https://github.com/localgovdrupal/localgov_guides/issues/87.

The changes are based on the PHP documentation for the function [array_search](https://www.php.net/manual/en/function.array-search.php).

`$this->guidePages` contains an array of nodes, in which we're looking for a node `$this->node`, so it should make sense to enforce `strict` comparison of objects.

This change fixes the `Fatal error: Nesting level too deep - recursive dependency? in /web/modules/contrib/localgov_guides/src/Plugin/Block/GuidesPrevNextBlock.php on line 31` on PHP `8.1`.