### PR TITLE
Add search result highlight to search result highlight display

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_guides_overview.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_guides_overview.search_result.yml
@@ -10,22 +10,19 @@ dependencies:
     - field.field.node.localgov_guides_overview.localgov_guides_section_title
     - node.type.localgov_guides_overview
   module:
-    - text
     - user
 id: node.localgov_guides_overview.search_result
 targetEntityType: node
 bundle: localgov_guides_overview
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   links: true
   localgov_guides_description: true
   localgov_guides_list_format: true
@@ -33,4 +30,3 @@ hidden:
   localgov_guides_section_title: true
   localgov_services_parent: true
   localgov_topic_classified: true
-  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_guides_page.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_guides_page.search_result.yml
@@ -8,23 +8,19 @@ dependencies:
     - field.field.node.localgov_guides_page.localgov_guides_section_title
     - node.type.localgov_guides_page
   module:
-    - text
     - user
 id: node.localgov_guides_page.search_result
 targetEntityType: node
 bundle: localgov_guides_page
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   links: true
   localgov_guides_parent: true
   localgov_guides_section_title: true
-  search_api_excerpt: true

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -189,4 +189,5 @@ class PagesIntegrationTest extends BrowserTestBase {
     $this->assertSession()->responseContains('<strong>certainly</strong>');
     $this->assertSession()->responseContains('<strong>question</strong>');
   }
+
 }

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -184,7 +184,7 @@ class PagesIntegrationTest extends BrowserTestBase {
     $this->assertSession()->responseContains('<strong>dogma</strong>');
     $this->assertSession()->responseContains('<strong>revelation</strong>');
     $this->drupalGet('search', ['query' => ['s' => 'truth+certainly+question']]);
-    $this->assertSession()->pageTextContains($$title_2);
+    $this->assertSession()->pageTextContains($title_2);
     $this->assertSession()->responseContains('<strong>truth</strong>');
     $this->assertSession()->responseContains('<strong>certainly</strong>');
     $this->assertSession()->responseContains('<strong>question</strong>');

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -8,6 +8,7 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
 use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
 
 /**
  * Tests pages working together with pathauto, services and topics.
@@ -19,6 +20,7 @@ class PagesIntegrationTest extends BrowserTestBase {
   use NodeCreationTrait;
   use AssertBreadcrumbTrait;
   use TaxonomyTestTrait;
+  use CronRunTrait;
 
   /**
    * Test breadcrumbs in the Standard profile.
@@ -58,6 +60,8 @@ class PagesIntegrationTest extends BrowserTestBase {
     'localgov_services_navigation',
     'localgov_topics',
     'localgov_guides',
+    'localgov_search',
+    'localgov_search_db',
   ];
 
   /**
@@ -147,4 +151,42 @@ class PagesIntegrationTest extends BrowserTestBase {
     $this->assertBreadcrumb(NULL, $trail);
   }
 
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+    $title_1 = 'Test Overview Page';
+    $body_1 = [
+      'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+    $this->createNode([
+      'title' => $title_1,
+      'body' => $body_1,
+      'type' => 'localgov_guides_overview',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $title_2 = 'Test Guide Page';
+    $body_2 = [
+      'value' => 'Truth, I have learned, differs for everybody. Just as no two people ever see a rainbow in exactly the same place - and yet both most certainly see it, while the person seemingly standing right underneath it does not see it at all - so truth is a question of where one stands, and the direction one is looking in at the time.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+    $this->createNode([
+      'title' => $title_2,
+      'body' => $body_2,
+      'type' => 'localgov_guides_page',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->cronRun();
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains($title_1);
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
+    $this->drupalGet('search', ['query' => ['s' => 'truth+certainly+question']]);
+    $this->assertSession()->pageTextContains($$title_2);
+    $this->assertSession()->responseContains('<strong>truth</strong>');
+    $this->assertSession()->responseContains('<strong>certainly</strong>');
+    $this->assertSession()->responseContains('<strong>question</strong>');
+  }
 }


### PR DESCRIPTION
Fix #93

Usual cavet about using search_api as dependency applies (If not using search_api, the search result display will be blank)
