### PR TITLE
2.0.10 release

### DIFF
--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\localgov_guides\EventSubscriber;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\node\Entity\Node;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
@@ -26,24 +27,31 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
    * Set page title and lede.
    */
   public function setPageHeader(PageHeaderDisplayEvent $event) {
-    if ($event->getEntity() instanceof Node &&
-      $event->getEntity()->bundle() == 'localgov_guides_page' &&
-      $event->getEntity()->localgov_guides_parent->entity
-    ) {
-      $overview = $event->getEntity()->localgov_guides_parent->entity;
-      if (!empty($overview)) {
-        $event->setTitle($overview->getTitle());
-        if ($overview->get('body')->summary) {
-          $event->setLede([
-            '#type' => 'html_tag',
-            '#tag' => 'p',
-            '#value' => $overview->get('body')->summary,
-          ]);
-        }
+
+    $node = $event->getEntity();
+
+    if (!$node instanceof Node) {
+      return;
+    }
+
+    if ($node->bundle() !== 'localgov_guides_page') {
+      return;
+    }
+
+    $overview = $node->localgov_guides_parent->entity;
+    if (!empty($overview)) {
+      $event->setTitle($overview->getTitle());
+      if ($overview->get('body')->summary) {
+        $event->setLede([
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $overview->get('body')->summary,
+        ]);
       }
-      else {
-        $event->setLede('');
-      }
+      $event->setCacheTags(Cache::mergeTags($node->getCacheTags(), $overview->getCacheTags()));
+    }
+    else {
+      $event->setLede('');
     }
   }
 

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -90,6 +90,14 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $this->drupalGet($orphan->toUrl()->toString());
     $this->assertSession()->responseNotContains('<h1 class="header">' . $overview_title . '</h1>');
     $this->assertSession()->responseContains('<h1 class="header">' . $orphan_title . '</h1>');
+
+    $new_overview_title = 'Guide overview - ' . $this->randomMachineName(8);
+    $overview->set('title', $new_overview_title);
+    $overview->save();
+
+    $this->drupalGet($page->toUrl()->toString());
+    $this->assertSession()->responseNotContains($overview_title);
+    $this->assertSession()->responseContains('<h1 class="header">' . $new_overview_title . '</h1>');
   }
 
 }


### PR DESCRIPTION
* Adds cache tags to the PageHeaderDisplayEvent, so the block can be updated on guide pages when their overview is changed.

* Test for #98 page header block caching.

* Coding standards.

Co-authored-by: Rupert Jabelman <rupert@jabelman.org>