### PR TITLE
Show summary on overview edit page

### DIFF
--- a/config/install/core.entity_form_display.node.localgov_guides_overview.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_guides_overview.default.yml
@@ -23,7 +23,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:


### PR DESCRIPTION
Fixes #110

With this change the overview edit page looks like

![image](https://user-images.githubusercontent.com/7189914/236248866-eccd6849-f43d-4642-937f-ae715ddfc50e.png)