### PR TITLE
Fix: Suppressing PHP 8.2 warning.

### DIFF
--- a/src/Plugin/Block/GuidesAbstractBaseBlock.php
+++ b/src/Plugin/Block/GuidesAbstractBaseBlock.php
@@ -50,6 +50,20 @@ abstract class GuidesAbstractBaseBlock extends BlockBase implements ContainerFac
   protected $format = '';
 
   /**
+   * Entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Current route object.
+   *
+   * @var \Drupal\Core\Routing\ResettableStackedRouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {


### PR DESCRIPTION
Suppressing PHP 8.2's dynamic property deprecation warnings.

@see https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties