### PR TITLE
fix: phpstan issues

### DIFF
--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -38,7 +38,7 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $overview = $node->localgov_guides_parent->entity ?? null;
+    $overview = $node->localgov_guides_parent->entity ?? NULL;
     if (!empty($overview)) {
       $event->setTitle($overview->getTitle());
       if ($overview->get('body')->summary) {

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -38,7 +38,7 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $overview = $node->localgov_guides_parent->entity;
+    $overview = $node->localgov_guides_parent->entity ?? null;
     if (!empty($overview)) {
       $event->setTitle($overview->getTitle());
       if ($overview->get('body')->summary) {

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -48,7 +48,7 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $this->adminUser = $this->drupalCreateUser(['administer blocks']);
     $this->drupalLogin($this->adminUser);
     $this->drupalPlaceBlock('localgov_page_header_block');
-    $this->drupalLogout($this->adminUser);
+    $this->drupalLogout();
   }
 
   /**

--- a/tests/src/Functional/PrevNextBlockTest.php
+++ b/tests/src/Functional/PrevNextBlockTest.php
@@ -48,7 +48,7 @@ class PrevNextBlockTest extends BrowserTestBase {
     $this->adminUser = $this->drupalCreateUser(['administer blocks']);
     $this->drupalLogin($this->adminUser);
     $this->drupalPlaceBlock('localgov_guides_prev_next_block');
-    $this->drupalLogout($this->adminUser);
+    $this->drupalLogout();
   }
 
   /**


### PR DESCRIPTION
Fix issues reported in https://github.com/localgovdrupal/localgov_guides/issues/127

@Adnan-cds I tested PHPStan with both 1.10.x dev and 1.11.x dev and the error `Variable {NAME}  in empty() always exists and is not falsy.` was still present so I've tweaked the handling here to be more robust so it passes PHPStan checks.