### PR TITLE
Fix `previous_title` shown instead of `next_title`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'
@@ -106,9 +103,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'
@@ -142,9 +136,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'
@@ -177,9 +168,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'

--- a/templates/guides-prev-next-block.html.twig
+++ b/templates/guides-prev-next-block.html.twig
@@ -18,7 +18,7 @@
   <a href="{{ next_url }}" class="btn btn-primary localgov_guides--next" aria-label="{{ 'Next'|t }}: {{ next_title }}">
     <span class="fa fa-chevron-right"></span>{{ 'Next'|t }}
     {% if show_title == 1 %}
-      <span>{{ previous_title }}</span>
+      <span>{{ next_title }}</span>
     {% endif %}
     </a>
   {% endif %}


### PR DESCRIPTION
Fixes https://github.com/localgovdrupal/localgov_guides/issues/146