### PR TITLE
Initialise guidePages as an array as it is used within array_filter even though it starts of as null

### DIFF
--- a/src/Plugin/Block/GuidesAbstractBaseBlock.php
+++ b/src/Plugin/Block/GuidesAbstractBaseBlock.php
@@ -97,6 +97,9 @@ abstract class GuidesAbstractBaseBlock extends BlockBase implements ContainerFac
    */
   protected function setPages() {
     if (is_null($this->guidePages)) {
+      // Initialise guidePages as an array.
+      $this->guidePages = [];
+
       if ($this->node->bundle() == 'localgov_guides_overview') {
         $this->overview = $this->node;
       }


### PR DESCRIPTION
Without this, new `Guide overview` pages display an error.

```
TypeError: array_filter(): Argument #1 ($array) must be of type array, null given in array_filter() (line 113 of modules/contrib/localgov_guides/src/Plugin/Block/GuidesAbstractBaseBlock.php).
```