### PR TITLE
Show titles in previous next navigation by default

### DIFF
--- a/config/optional/block.block.localgov_guides_prev_next_block_base.yml
+++ b/config/optional/block.block.localgov_guides_prev_next_block_base.yml
@@ -16,4 +16,5 @@ settings:
   label: 'Guides prev next block'
   provider: localgov_guides
   label_display: '0'
+  show_title: true
 visibility: {  }

--- a/config/optional/block.block.localgov_guides_prev_next_block_scarfolk.yml
+++ b/config/optional/block.block.localgov_guides_prev_next_block_scarfolk.yml
@@ -16,4 +16,5 @@ settings:
   label: 'Guides prev next block'
   provider: localgov_guides
   label_display: '0'
+  show_title: true
 visibility: {  }


### PR DESCRIPTION
Without this change a default install looks lie

![image](https://github.com/localgovdrupal/localgov_guides/assets/7189914/648999bc-a08d-42d8-bb46-3cfe48119220)

With this change it will looks like

![image](https://github.com/localgovdrupal/localgov_guides/assets/7189914/2420e421-8994-4326-aa28-5a827fcde660)

Fixes #129