### PR TITLE
fix: failing test due to duplicate drupalLogout call

### DIFF
--- a/tests/src/Functional/GuidePagesTest.php
+++ b/tests/src/Functional/GuidePagesTest.php
@@ -134,7 +134,6 @@ class GuidePagesTest extends BrowserTestBase {
       'status' => NodeInterface::NOT_PUBLISHED,
       'localgov_guides_parent' => ['target_id' => $guide_overview_page->id()],
     ]);
-    $this->drupalLogout();
     $this->drupalGet($guide_overview_page->toUrl()->toString());
     $this->assertSession()->statusCodeEquals(403);
     $this->drupalGet($guide_page_1->toUrl()->toString());


### PR DESCRIPTION
This fixes the following test failure:

```
1) Drupal\Tests\localgov_guides\Functional\GuidePagesTest::testUnpublishedGuidePages
Behat\Mink\Exception\ElementNotFoundException: Element matching xpath "//form[@id='user-logout-confirm']" not found.

/app/vendor/behat/mink/src/WebAssert.php:465
/app/web/core/tests/Drupal/Tests/UiHelperTrait.php:73
/app/web/core/tests/Drupal/Tests/UiHelperTrait.php:187
/app/web/modules/contrib/localgov_guides/tests/src/Functional/GuidePagesTest.php:138
/app/vendor/phpunit/phpunit/src/Framework/TestResult.php:729
```

This is due to duplicate `drupalLogout` calls and the second call causes a redirect so it is not finding the element, the first call to `drupalLogout` is line 110.