### PR TITLE
fix: drop drupal 10.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
+        "drupal/core": "^10.2",
         "localgovdrupal/localgov_core": "^2.12"
     },
     "require-dev": {

--- a/localgov_guides.info.yml
+++ b/localgov_guides.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Guides
 description: Guides with overview, pages, and navigation.
 type: module
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10.2
 
 dependencies:
   - localgov_core:localgov_core

--- a/tests/src/Kernel/OverviewPageIntegrity.php
+++ b/tests/src/Kernel/OverviewPageIntegrity.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\localgov_guides\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
@@ -16,10 +16,7 @@ use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
 class OverviewPageIntegrity extends KernelTestBase {
 
   use ContentTypeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
   use NodeCreationTrait;
   use PathautoTestHelperTrait;
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Drop Drupal 10.1 support, 10.1 was EoL June 2024

Change record: https://www.drupal.org/node/3401941