### PR TITLE
adds field for guide navigation layout type

### DIFF
--- a/config/install/core.entity_form_display.node.localgov_guides_overview.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_guides_overview.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_guides_overview.body
+    - field.field.node.localgov_guides_overview.localgov_guides_list_layout
     - field.field.node.localgov_guides_overview.localgov_guides_list_format
     - field.field.node.localgov_guides_overview.localgov_guides_pages
     - field.field.node.localgov_guides_overview.localgov_guides_section_title
@@ -35,6 +36,12 @@ content:
   localgov_guides_list_format:
     type: options_select
     weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  localgov_guides_list_layout:
+    type: options_select
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/field.field.node.localgov_guides_overview.localgov_guides_list_layout.yml
+++ b/config/install/field.field.node.localgov_guides_overview.localgov_guides_list_layout.yml
@@ -14,7 +14,9 @@ label: 'List Layout'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: vertical
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/install/field.field.node.localgov_guides_overview.localgov_guides_list_layout.yml
+++ b/config/install/field.field.node.localgov_guides_overview.localgov_guides_list_layout.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_guides_list_layout
+    - node.type.localgov_guides_overview
+  module:
+    - options
+id: node.localgov_guides_overview.localgov_guides_list_layout
+field_name: localgov_guides_list_layout
+entity_type: node
+bundle: localgov_guides_overview
+label: 'List Layout'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.storage.node.localgov_guides_list_layout.yml
+++ b/config/install/field.storage.node.localgov_guides_list_layout.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.localgov_guides_list_layout
+field_name: localgov_guides_list_layout
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: horizontal
+      label: 'Horizontal (multiple columns)'
+    -
+      value: vertical
+      label: 'Vertical (single column)'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_guide.yml
+++ b/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_guide.yml
@@ -3,8 +3,8 @@ status: true
 dependencies:
   enforced:
     module:
-    - localgov_guides
-    - localgov_menu_link_group
+      - localgov_guides
+      - localgov_menu_link_group
 id: localgov_menu_link_group_guide
 group_label: Guide
 weight: 0

--- a/src/Plugin/Block/GuidesContentsBlock.php
+++ b/src/Plugin/Block/GuidesContentsBlock.php
@@ -20,9 +20,17 @@ class GuidesContentsBlock extends GuidesAbstractBaseBlock {
   public function build() {
     $this->setPages();
     $links = [];
+    $layout_type = FALSE;
+    $layout_type_field = $this->overview->get('localgov_guides_list_layout');
+
+    if (!empty($layout_type_field) && isset($layout_type_field->getValue()[0])) {
+      $layout_type = $layout_type_field->getValue()[0]['value'];
+      $layout_type = str_replace('_', '-', $layout_type);
+    }
 
     $options = $this->node->id() == $this->overview->id() ? ['attributes' => ['class' => 'active']] : [];
     $links[] = $this->overview->toLink($this->overview->localgov_guides_section_title->value, 'canonical', $options);
+
     foreach ($this->guidePages as $guide_node) {
       $options = $this->node->id() == $guide_node->id() ? ['attributes' => ['class' => 'active']] : [];
       $links[] = $guide_node->toLink($guide_node->localgov_guides_section_title->value, 'canonical', $options);
@@ -34,6 +42,10 @@ class GuidesContentsBlock extends GuidesAbstractBaseBlock {
       '#links' => $links,
       '#format' => $this->format,
     ];
+
+    if ($layout_type) {
+      $build['#attributes']['class'][] = 'block-localgov-guides-contents--' . $layout_type;
+    }
 
     return $build;
   }

--- a/src/Plugin/Block/GuidesContentsBlock.php
+++ b/src/Plugin/Block/GuidesContentsBlock.php
@@ -21,11 +21,13 @@ class GuidesContentsBlock extends GuidesAbstractBaseBlock {
     $this->setPages();
     $links = [];
     $layout_type = FALSE;
-    $layout_type_field = $this->overview->get('localgov_guides_list_layout');
 
-    if (!empty($layout_type_field) && isset($layout_type_field->getValue()[0])) {
-      $layout_type = $layout_type_field->getValue()[0]['value'];
-      $layout_type = str_replace('_', '-', $layout_type);
+    if ($this->overview->hasField('localgov_guides_list_layout')) {
+      $layout_type_field = $this->overview->get('localgov_guides_list_layout');
+      if (!empty($layout_type_field) && isset($layout_type_field->getValue()[0])) {
+        $layout_type = $layout_type_field->getValue()[0]['value'];
+        $layout_type = str_replace('_', '-', $layout_type);
+      }
     }
 
     $options = $this->node->id() == $this->overview->id() ? ['attributes' => ['class' => 'active']] : [];


### PR DESCRIPTION
Closes #123 

## What does this change?

- Adds a new field called "List Layout" so editors can choose on a per-guide basis whether they want horizonal/vertical layout.
- Defaults to "Vertical (Single Column)"

![Screenshot 2024-11-28 at 14 53 02](https://github.com/user-attachments/assets/5982cf63-e0fd-4f83-9233-caad26bd3d85)


## How to test

Install Guides module
Create a guide overview and some guide pages
In Guide Overview, choose "Horizontal" or "Vertical" for the "List Layout"
Check that the Guide Nav responds accordingly **NOTE** it will need [this PR from LocalGov base](https://github.com/localgovdrupal/localgov_base/pull/665) which has the required CSS.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.