### PR TITLE
fix: superfluous semicolon causing phpcs failure

### DIFF
--- a/localgov_guides.module
+++ b/localgov_guides.module
@@ -208,7 +208,7 @@ function localgov_guides_preprocess_node__localgov_guides_overview__full(&$vars)
 
   if ($guide_overview_node->hasField('localgov_guides_section_title') && !$guide_overview_node->localgov_guides_section_title->isEmpty()) {
     $guide_overview_title = $guide_overview_node->localgov_guides_section_title->value;
-  };
+  }
 
   $vars['guide_overview_title'] = $guide_overview_title ?: $guide_overview_default_title;
 }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes coding standards failure https://github.com/localgovdrupal/localgov_project/actions/runs/12704937891/job/35415143460

It looks to have been an upstream standards change which now flags

```
FILE: ...ov_project/html/web/modules/contrib/localgov_guides/localgov_guides.module
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------
 211 | WARNING | [x] Empty PHP statement detected: superfluous semicolon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------
```