### PR TITLE
Check for body field before acting on it

### DIFF
--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -52,7 +52,7 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
     if ($overview instanceof NodeInterface) {
       $overview = $this->entityRepository->getTranslationFromContext($overview);
       $event->setTitle($overview->getTitle());
-      if ($overview->get('body')->summary) {
+      if ($overview->hasField('body') && $overview->get('body')->summary) {
         $event->setLede([
           '#type' => 'html_tag',
           '#tag' => 'p',

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -63,6 +63,10 @@ class PageHeaderBlockTest extends BrowserTestBase {
       'title' => $overview_title,
       'type' => 'localgov_guides_overview',
       'status' => NodeInterface::PUBLISHED,
+      'body' => [
+        'summary' => 'Lede to show',
+        'value' => '',
+      ],
     ]);
 
     $page_title = 'Guide page - ' . $this->randomMachineName(8);
@@ -84,6 +88,7 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $query = $this->xpath('.//h1[contains(concat(" ",normalize-space(@class)," ")," header ")]');
     $found_title = $query[0]->getText();
     $this->assertEquals($found_title, $overview_title);
+    $this->assertSession()->responseContains('Lede to show');
 
     $this->drupalGet($page->toUrl()->toString());
     $query = $this->xpath('.//h1[contains(concat(" ",normalize-space(@class)," ")," header ")]');
@@ -103,6 +108,23 @@ class PageHeaderBlockTest extends BrowserTestBase {
 
     $this->drupalGet($page->toUrl()->toString());
     $this->assertSession()->responseNotContains($overview_title);
+    $query = $this->xpath('.//h1[contains(concat(" ",normalize-space(@class)," ")," header ")]');
+    $found_title = $query[0]->getText();
+    $this->assertEquals($found_title, $new_overview_title);
+
+    // Check lede.
+    $this->drupalGet($page->toUrl()->toString());
+    $this->assertSession()->responseContains('Lede to show');
+    // Remove body field, check title and no lede.
+    $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions('node', 'localgov_guides_overview');
+    $field_definitions['body']->delete();
+    $this->drupalGet($overview->toUrl()->toString());
+    $this->assertSession()->responseNotContains('Lede to show');
+    // @todo remove this.
+    drupal_flush_all_caches();
+    // @todo end.
+    $this->drupalGet($page->toUrl()->toString());
+    $this->assertSession()->responseNotContains('Lede to show');
     $query = $this->xpath('.//h1[contains(concat(" ",normalize-space(@class)," ")," header ")]');
     $found_title = $query[0]->getText();
     $this->assertEquals($found_title, $new_overview_title);

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -121,8 +121,8 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $this->drupalGet($overview->toUrl()->toString());
     $this->assertSession()->responseNotContains('Lede to show');
     // @todo remove this.
+    // Issue https://github.com/localgovdrupal/localgov_core/issues/290
     drupal_flush_all_caches();
-    // @todo end.
     $this->drupalGet($page->toUrl()->toString());
     $this->assertSession()->responseNotContains('Lede to show');
     $query = $this->xpath('.//h1[contains(concat(" ",normalize-space(@class)," ")," header ")]');


### PR DESCRIPTION
Closes #188 

## What does this change?

Simple check to see if the body field exists before we act on it.

## How to test

Delete body field from guide page content type, the pageHeader block will cause a WSOD. Checkout this branch, clear your cache, and then refresh your page and the pageHeader block should be working again.
