### PR TITLE
Updated declaration of Drupal\localgov_guides\Plugin\Block\GuidesPreNextBlock::submitConfigurationForm()

### DIFF
--- a/src/Plugin/Block/GuidesPrevNextBlock.php
+++ b/src/Plugin/Block/GuidesPrevNextBlock.php
@@ -74,7 +74,7 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     parent::blockSubmit($form, $form_state);
 
     $values = $form_state->getValues();


### PR DESCRIPTION
Fixes #191

## What does this change?

Fixes PHP Fatal error:  Declaration of Drupal\localgov_guides\Plugin\Block\GuidesPrevNextBlock::submitConfigurationForm(array &$form, Drupal\Core\Form\FormStateInterface $form_state) must be compatible with Drupal\Core\Block\BlockBase::submitConfigurationForm(array &$form, Drupal\Core\Form\FormStateInterface $form_state): void in /app/web/modules/contrib/localgov_guides/src/Plugin/Block/GuidesPrevNextBlock.php on line 77

## How to test

All PHPUnit tests pass