### PR TITLE
Fixes prefixes (subdirectory, language) being included in parent path pattern for other instances.

### DIFF
--- a/config/optional/pathauto.pattern.localgov_guides_page.yml
+++ b/config/optional/pathauto.pattern.localgov_guides_page.yml
@@ -6,7 +6,7 @@ dependencies:
 id: localgov_guides_page
 label: 'Guide page'
 type: 'canonical_entities:node'
-pattern: '[node:localgov_guides_parent:entity:url:relative]/[node:title]'
+pattern: '[node:localgov_guides_parent:entity:url:path]/[node:title]'
 selection_criteria:
   1ceaab92-3301-4e34-a8de-9dbcae184528:
     id: 'entity_bundle:node'

--- a/localgov_guides.post_update.php
+++ b/localgov_guides.post_update.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for LocalGov Guides.
+ */
+
+use Drupal\pathauto\Entity\PathautoPattern;
+use Drupal\pathauto\PathautoPatternInterface;
+
+/**
+ * Update pathauto patterns to avoid inclusion of subdirectory, language, etc.
+ */
+function localgov_guides_post_update_pathauto_parent(): void {
+  $alias = PathautoPattern::load('localgov_guides_page');
+  if ($alias instanceof PathautoPatternInterface &&
+    $alias->getPattern() == '[node:localgov_guides_parent:entity:url:relative]/[node:title]'
+  ) {
+    $alias->setPattern('[node:localgov_guides_parent:entity:url:path]/[node:title]');
+    $alias->save();
+  }
+}


### PR DESCRIPTION
See https://github.com/localgovdrupal/localgov_services/issues/335#issuecomment-3461396195 and https://github.com/localgovdrupal/localgov_services/pull/337