### PR TITLE
Fix error setting the previous_title link when the overview does not have a section title. See #198.

### DIFF
--- a/src/Plugin/Block/GuidesPrevNextBlock.php
+++ b/src/Plugin/Block/GuidesPrevNextBlock.php
@@ -38,7 +38,7 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
       else {
         $previous_url = $this->overview->toUrl();
         $previous_title = $this->overview->title->value;
-        // If the overview has a section title, use that instead of the overview title.
+        // If the overview has a section title, use that instead of the title.
         if (!empty($this->overview->localgov_guides_section_title->value)) {
           $previous_title = $this->overview->localgov_guides_section_title->value;
         }

--- a/src/Plugin/Block/GuidesPrevNextBlock.php
+++ b/src/Plugin/Block/GuidesPrevNextBlock.php
@@ -39,7 +39,7 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
         $previous_url = $this->overview->toUrl();
         $previous_title = $this->overview->title->value;
         // If the overview has a section title, use that instead of the title.
-        if (!empty($this->overview->localgov_guides_section_title->value)) {
+        if (!$this->overview->localgov_guides_section_title->isEmpty()) {
           $previous_title = $this->overview->localgov_guides_section_title->value;
         }
       }

--- a/src/Plugin/Block/GuidesPrevNextBlock.php
+++ b/src/Plugin/Block/GuidesPrevNextBlock.php
@@ -37,7 +37,11 @@ class GuidesPrevNextBlock extends GuidesAbstractBaseBlock {
       }
       else {
         $previous_url = $this->overview->toUrl();
-        $previous_title = $this->overview->localgov_guides_section_title->value;
+        $previous_title = $this->overview->title->value;
+        // If the overview has a section title, use that instead of the overview title.
+        if (!empty($this->overview->localgov_guides_section_title->value)) {
+          $previous_title = $this->overview->localgov_guides_section_title->value;
+        }
       }
       if (!empty($this->guidePages[$page_delta + 1])) {
         $next_url = $this->guidePages[$page_delta + 1]->toUrl();

--- a/tests/src/Functional/GuidePagesTest.php
+++ b/tests/src/Functional/GuidePagesTest.php
@@ -175,4 +175,37 @@ class GuidePagesTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains($guide_page_title_2);
   }
 
+  /**
+   * Test with and without section title.
+   */
+  public function testSectionTitleGuidePages() {
+    $guide_overview_title = 'Guide overview - ' . $this->randomMachineName(8);
+    $guide_body_text = 'Vestibulum scelerisque viverra diam in cursus. Donec interdum eget tellus sed volutpat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec tempus at neque vitae tempor. Aenean tristique elit id ultrices ornare. Morbi a mauris magna. Ut diam dui, venenatis non purus in, tincidunt aliquet diam. Maecenas a mattis sapien. Duis ultricies lacinia tortor, et interdum ante rhoncus id. Ut ultrices leo et dui aliquam placerat. Nullam egestas eros a lectus venenatis, vel mattis dolor consectetur. Sed ac mattis purus. Duis vulputate nisi nisl, a varius ligula accumsan non. Praesent sed ipsum nunc. Cras tincidunt, metus in commodo pulvinar, tortor nisi consequat est, ac porttitor orci eros id sem. Suspendisse rutrum risus arcu, quis placerat dolor pulvinar quis.';
+
+    $guide_page_title_1 = 'Guide page - ' . $this->randomMachineName(8);
+    $guide_overview_page = $this->createNode([
+      'title' => $guide_overview_title,
+      'type' => 'localgov_guides_overview',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $guide_page_1 = $this->createNode([
+      'title' => $guide_page_title_1,
+      'type' => 'localgov_guides_page',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_guides_parent' => ['target_id' => $guide_overview_page->id()],
+    ]);
+    $this->drupalGet($guide_overview_page->toUrl()->toString());
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet($guide_page_1->toUrl()->toString());
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains($guide_overview_title);
+
+    $guide_summary_text = 'Aenean semper sodales augue. In volutpat quam id nisi accumsan scelerisque. Phasellus et dignissim arcu. Quisque vulputate ligula ac mauris consectetur bibendum. Phasellus ultrices velit ultrices efficitur sodales.';
+    $guide_overview_page->set('localgov_guides_section_title', $guide_summary_text);
+    $guide_overview_page->save();
+    $this->drupalGet($guide_page_1->toUrl()->toString());
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains($guide_summary_text);
+  }
+
 }

--- a/tests/src/Functional/GuidePagesTest.php
+++ b/tests/src/Functional/GuidePagesTest.php
@@ -180,8 +180,6 @@ class GuidePagesTest extends BrowserTestBase {
    */
   public function testSectionTitleGuidePages() {
     $guide_overview_title = 'Guide overview - ' . $this->randomMachineName(8);
-    $guide_body_text = 'Vestibulum scelerisque viverra diam in cursus. Donec interdum eget tellus sed volutpat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec tempus at neque vitae tempor. Aenean tristique elit id ultrices ornare. Morbi a mauris magna. Ut diam dui, venenatis non purus in, tincidunt aliquet diam. Maecenas a mattis sapien. Duis ultricies lacinia tortor, et interdum ante rhoncus id. Ut ultrices leo et dui aliquam placerat. Nullam egestas eros a lectus venenatis, vel mattis dolor consectetur. Sed ac mattis purus. Duis vulputate nisi nisl, a varius ligula accumsan non. Praesent sed ipsum nunc. Cras tincidunt, metus in commodo pulvinar, tortor nisi consequat est, ac porttitor orci eros id sem. Suspendisse rutrum risus arcu, quis placerat dolor pulvinar quis.';
-
     $guide_page_title_1 = 'Guide page - ' . $this->randomMachineName(8);
     $guide_overview_page = $this->createNode([
       'title' => $guide_overview_title,

--- a/tests/src/Functional/GuidePagesTest.php
+++ b/tests/src/Functional/GuidePagesTest.php
@@ -74,7 +74,7 @@ class GuidePagesTest extends BrowserTestBase {
   /**
    * Verifies basic functionality with all modules.
    */
-  public function testConfigForm() {
+  public function testConfigForm(): void {
     $this->drupalLogin($this->adminUser);
     $this->drupalGet('/admin/structure/types/manage/localgov_guides_overview/fields');
     $this->assertSession()->pageTextContains('Guide pages');
@@ -88,7 +88,7 @@ class GuidePagesTest extends BrowserTestBase {
   /**
    * Test adding unpublished guide pages via /node/add form.
    */
-  public function testUnpublishedGuidePages() {
+  public function testUnpublishedGuidePages(): void {
     $guide_overview_title = 'Guide overview - ' . $this->randomMachineName(8);
     $guide_summary_text = 'Aenean semper sodales augue. In volutpat quam id nisi accumsan scelerisque. Phasellus et dignissim arcu. Quisque vulputate ligula ac mauris consectetur bibendum. Phasellus ultrices velit ultrices efficitur sodales.';
     $guide_body_text = 'Vestibulum scelerisque viverra diam in cursus. Donec interdum eget tellus sed volutpat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec tempus at neque vitae tempor. Aenean tristique elit id ultrices ornare. Morbi a mauris magna. Ut diam dui, venenatis non purus in, tincidunt aliquet diam. Maecenas a mattis sapien. Duis ultricies lacinia tortor, et interdum ante rhoncus id. Ut ultrices leo et dui aliquam placerat. Nullam egestas eros a lectus venenatis, vel mattis dolor consectetur. Sed ac mattis purus. Duis vulputate nisi nisl, a varius ligula accumsan non. Praesent sed ipsum nunc. Cras tincidunt, metus in commodo pulvinar, tortor nisi consequat est, ac porttitor orci eros id sem. Suspendisse rutrum risus arcu, quis placerat dolor pulvinar quis.';
@@ -178,7 +178,7 @@ class GuidePagesTest extends BrowserTestBase {
   /**
    * Test with and without section title.
    */
-  public function testSectionTitleGuidePages() {
+  public function testSectionTitleGuidePages(): void {
     $guide_overview_title = 'Guide overview - ' . $this->randomMachineName(8);
     $guide_page_title_1 = 'Guide page - ' . $this->randomMachineName(8);
     $guide_overview_page = $this->createNode([


### PR DESCRIPTION
This should fix the fatal error we are seeing on https://github.com/localgovdrupal/localgov_subsites_extras/issues/39

We should follow up as discussed yesterday on harmonising the logic for section titles, whether they are required and how the we. make use of them for previous next navigation links.  

CC @markconroy @ekes 

### Steps to test: 

1. Default install of LocalGov Drupal with LocalGov Guides on 2.x branch
2. Create Guide overview page with **no section title**
3. Create guide page with parent of the overview. 
4. Save
5. See error

> Drupal\Core\Render\Component\Exception\InvalidComponentException: [prev_title] NULL value found, but a string or an object is required.

6. Checkout this branch 
7. No error :) 

